### PR TITLE
Update NuGet dependencies to latest 2026.3.x versions

### DIFF
--- a/MessagingService.BusinessLogic/MessagingService.BusinessLogic.csproj
+++ b/MessagingService.BusinessLogic/MessagingService.BusinessLogic.csproj
@@ -5,8 +5,8 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.1" />
-    <PackageReference Include="MediatR" Version="14.0.0" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
+    <PackageReference Include="MediatR" Version="14.1.0" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />

--- a/MessagingService.Client/MessagingService.Client.csproj
+++ b/MessagingService.Client/MessagingService.Client.csproj
@@ -6,9 +6,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Shared.Results" Version="2026.2.2" />
+    <PackageReference Include="Shared.Results" Version="2026.3.1" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/MessagingService.EmailAggregate.Tests/MessagingService.EmailAggregate.Tests.csproj
+++ b/MessagingService.EmailAggregate.Tests/MessagingService.EmailAggregate.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+    <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/MessagingService.EmailMessage.DomainEvents/MessagingService.EmailMessage.DomainEvents.csproj
+++ b/MessagingService.EmailMessage.DomainEvents/MessagingService.EmailMessage.DomainEvents.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Shared" Version="2026.2.2" />
-	<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
+	<PackageReference Include="Shared" Version="2026.3.1" />
+	<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
   </ItemGroup>
 
 </Project>

--- a/MessagingService.EmailMessageAggregate/MessagingService.EmailMessageAggregate.csproj
+++ b/MessagingService.EmailMessageAggregate/MessagingService.EmailMessageAggregate.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-	  <PackageReference Include="Shared" Version="2026.2.2" />
-	  <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+	  <PackageReference Include="Shared" Version="2026.3.1" />
+	  <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService.IntegrationTesting.Helpers/MessagingService.IntegrationTesting.Helpers.csproj
+++ b/MessagingService.IntegrationTesting.Helpers/MessagingService.IntegrationTesting.Helpers.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService.IntegrationTests/MessagingService.IntegrationTests.csproj
+++ b/MessagingService.IntegrationTests/MessagingService.IntegrationTests.csproj
@@ -6,17 +6,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
     <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
-	  <PackageReference Include="NUnit" Version="4.5.0" />
+	  <PackageReference Include="NUnit" Version="4.5.1" />
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Reqnroll" Version="3.3.3" />
     <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-    <PackageReference Include="SecurityService.Client" Version="2026.2.1" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.1" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.2.2" />
+    <PackageReference Include="SecurityService.Client" Version="2026.2.3" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.3" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/MessagingService.SMSMessage.DomainEvents/MessagingService.SMSMessage.DomainEvents.csproj
+++ b/MessagingService.SMSMessage.DomainEvents/MessagingService.SMSMessage.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.2.2" />
+    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
   </ItemGroup>
 
 </Project>

--- a/MessagingService.SMSMessageAggregate/MessagingService.SMSMessageAggregate.csproj
+++ b/MessagingService.SMSMessageAggregate/MessagingService.SMSMessageAggregate.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-    <PackageReference Include="Shared.EventStore" Version="2026.2.2" />
+    <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService/Bootstrapper/MediatorRegistry.cs
+++ b/MessagingService/Bootstrapper/MediatorRegistry.cs
@@ -3,28 +3,22 @@ using SimpleResults;
 
 namespace MessagingService.Bootstrapper;
 
-using System;
-using System.Diagnostics.CodeAnalysis;
 using BusinessLogic.RequestHandlers;
 using BusinessLogic.Requests;
+using Google.Api;
 using Lamar;
 using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using Shared.General;
+using System;
+using System.Diagnostics.CodeAnalysis;
 
 [ExcludeFromCodeCoverage]
 public class MediatorRegistry : ServiceRegistry
 {
     public MediatorRegistry()
     {
-        this.AddTransient<IMediator, Mediator>();
-        this.AddSingleton<IRequestHandler<EmailCommands.SendEmailCommand, Result<Guid>>, MessagingRequestHandler>();
-        this.AddSingleton<IRequestHandler<SMSCommands.SendSMSCommand, Result<Guid>>, MessagingRequestHandler>();
-        this.AddSingleton<IRequestHandler<EmailCommands.ResendEmailCommand,Result>, MessagingRequestHandler>();
-        this.AddSingleton<IRequestHandler<SMSCommands.ResendSMSCommand,Result>, MessagingRequestHandler>();
-        this.AddSingleton<IRequestHandler<SMSCommands.UpdateMessageStatusCommand, Result>, MessagingRequestHandler>();
-        this.AddSingleton<IRequestHandler<EmailCommands.UpdateMessageStatusCommand, Result>, MessagingRequestHandler>();
-
+        this.AddMediatR(cfg => cfg.RegisterServicesFromAssembly(typeof(MessagingRequestHandler).Assembly));
         this.AddSingleton<Func<String, String>>(container => (serviceName) => ConfigurationReader.GetBaseServerUri(serviceName).OriginalString);
     }
 }

--- a/MessagingService/MessagingService.csproj
+++ b/MessagingService/MessagingService.csproj
@@ -18,13 +18,13 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Shared" Version="2026.2.2" />
-	  <PackageReference Include="Shared.Logger" Version="2026.2.2" />
+    <PackageReference Include="Shared" Version="2026.3.1" />
+	  <PackageReference Include="Shared.Logger" Version="2026.3.1" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.1" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.2.2" />
-	  <PackageReference Include="ClientProxyBase" Version="2026.2.2" />
+    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.3.1" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
     <PackageReference Include="SimpleResults.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />

--- a/MessagingService/Startup.cs
+++ b/MessagingService/Startup.cs
@@ -88,8 +88,7 @@ namespace MessagingService
 
             ConfigurationReader.Initialise(Startup.Configuration);
             app.UseMiddleware<TenantMiddleware>();
-            app.AddRequestLogging();
-            app.AddResponseLogging();
+            app.AddRequestResponseLogging();
             app.AddExceptionHandler();
 
             app.UseRouting();


### PR DESCRIPTION

Upgraded all internal/shared package references from 2026.2.x to 2026.3.x across the solution. Also updated NLog.Extensions.Logging, MediatR, and NUnit to their latest patch versions. No code changes—dependency updates only.

closes #366 