### PR TITLE
Make Sentry options configurable via app settings

### DIFF
--- a/MessagingService/Program.cs
+++ b/MessagingService/Program.cs
@@ -91,7 +91,8 @@ namespace MessagingService
                                                                                          o.Dsn = builtConfig["SentryConfiguration:Dsn"];
                                                                                          o.SendDefaultPii = true;
                                                                                          o.MaxRequestBodySize = RequestSize.Always;
-                                                                                         o.CaptureBlockingCalls = true;
+                                                                                         o.CaptureBlockingCalls = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "CaptureBlockingCalls", false);
+                                                                                         o.IncludeActivityData = ConfigurationReader.GetValueOrDefault("SentryConfiguration", "IncludeActivityData", false);
                                                                                          o.Release = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
                                                                                      });
                                                                                  }


### PR DESCRIPTION
Replaced hardcoded Sentry CaptureBlockingCalls with a value read from configuration, defaulting to false. Added IncludeActivityData option, also configurable via settings. This improves flexibility and allows Sentry behavior to be controlled externally.

closes #373 