### PR TITLE
Refactor config for SMTP2Go & SMSWorks; use DI for settings

### DIFF
--- a/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoProxy.cs
+++ b/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoProxy.cs
@@ -15,6 +15,11 @@
     using System.Threading;
     using System.Threading.Tasks;
 
+    public record Smtp2GConfig {
+        public String BaseAddress { get; set; }
+        public String APIKey { get; set; }
+    }
+
     /// <summary>
     /// 
     /// </summary>
@@ -29,13 +34,15 @@
         /// </summary>
         private readonly HttpClient HttpClient;
 
+        private readonly Smtp2GConfig Configuration;
+
         #endregion
 
         #region Constructors
 
-        public Smtp2GoProxy(HttpClient httpClient)
-        {
+        public Smtp2GoProxy(HttpClient httpClient, Smtp2GConfig configuration) {
             this.HttpClient = httpClient;
+            this.Configuration = configuration;
         }
 
         #endregion
@@ -52,7 +59,7 @@
                                                                CancellationToken cancellationToken) {
             // Translate the request message
             Smtp2GoSendEmailRequest apiRequest = new() {
-                ApiKey = ConfigurationReader.GetValue("SMTP2GoAPIKey"),
+                ApiKey = Configuration.APIKey,
                 HTMLBody = isHtml ? body : string.Empty,
                 TextBody = isHtml ? string.Empty : body,
                 Sender = fromAddress,
@@ -72,7 +79,7 @@
 
             StringContent content = new(requestSerialised, Encoding.UTF8, "application/json");
 
-            String requestUri = $"{ConfigurationReader.GetValue("SMTP2GoBaseAddress")}email/send";
+            String requestUri = $"{Configuration.BaseAddress}email/send";
             HttpRequestMessage requestMessage = new(HttpMethod.Post, requestUri);
             requestMessage.Content = content;
 
@@ -109,7 +116,7 @@
                                                                   DateTime endDate,
                                                                   CancellationToken cancellationToken) {
             Smtp2GoEmailSearchRequest apiRequest = new() {
-                ApiKey = ConfigurationReader.GetValue("SMTP2GoAPIKey"), EmailId = new List<String> { providerReference }, StartDate = startDate.ToString("yyyy-MM-dd"), EndDate = endDate.ToString("yyyy-MM-dd"),
+                ApiKey = Configuration.APIKey, EmailId = new List<String> { providerReference }, StartDate = startDate.ToString("yyyy-MM-dd"), EndDate = endDate.ToString("yyyy-MM-dd"),
             };
 
             String requestSerialised = JsonConvert.SerializeObject(apiRequest, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None });
@@ -118,13 +125,13 @@
 
             StringContent content = new(requestSerialised, Encoding.UTF8, "application/json");
 
-            String requestUri = $"{ConfigurationReader.GetValue("SMTP2GoBaseAddress")}email/search";
+            String requestUri = $"{Configuration.BaseAddress}email/search";
             HttpRequestMessage requestMessage = new(HttpMethod.Post, requestUri);
             requestMessage.Content = content;
 
             HttpResponseMessage httpResponse = await this.HttpClient.SendAsync(requestMessage, cancellationToken);
 
-            Smtp2GoEmailSearchResponse apiResponse = JsonConvert.DeserializeObject<Smtp2GoEmailSearchResponse>(await httpResponse.Content.ReadAsStringAsync());
+            Smtp2GoEmailSearchResponse apiResponse = JsonConvert.DeserializeObject<Smtp2GoEmailSearchResponse>(await httpResponse.Content.ReadAsStringAsync(cancellationToken));
 
             Logger.LogDebug($"Response Message Received from Email Provider [SMTP2Go] {JsonConvert.SerializeObject(apiResponse)}");
 

--- a/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksProxy.cs
+++ b/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksProxy.cs
@@ -16,20 +16,24 @@ namespace MessagingService.BusinessLogic.Services.SMSServices.TheSMSWorks
     using Shared.Extensions;
     using Shared.General;
 
+    public record SmsWorksConfig {
+        public String BaseAddress { get; set; }
+        public String CustomerId { get; set; }
+        public String Key { get; set; }
+        public String Secret { get; set; }
+    }
+
     [ExcludeFromCodeCoverage]
     public class TheSmsWorksProxy : ISMSServiceProxy
     {
         private readonly HttpClient HttpClient;
+        private readonly SmsWorksConfig Configuration;
 
-        public TheSmsWorksProxy(HttpClient httpClient) {
+        public TheSmsWorksProxy(HttpClient httpClient, SmsWorksConfig configuration) {
             this.HttpClient = httpClient;
+            this.Configuration = configuration;
         }
-
-        private const String TheSMSWorksBaseAddressKey = "TheSMSWorksBaseAddress";
-        private const String TheSMSWorksCustomerIdKey = "TheSMSWorksCustomerId";
-        private const String TheSMSWorksKeyKey = "TheSMSWorksKey";
-        private const String TheSMSWorksSecretKey = "TheSMSWorksSecret";
-
+        
         /// <summary>
         /// Sends the SMS.
         /// </summary>
@@ -47,17 +51,16 @@ namespace MessagingService.BusinessLogic.Services.SMSServices.TheSMSWorks
             SMSServiceProxyResponse response = null;
 
             // Create the Auth Request                
-            TheSmsWorksTokenRequest apiTokenRequest = new() { CustomerId = ConfigurationReader.GetValue(TheSMSWorksCustomerIdKey), 
-                Key = ConfigurationReader.GetValue(TheSMSWorksKeyKey), Secret = ConfigurationReader.GetValue(TheSMSWorksSecretKey) };
+            TheSmsWorksTokenRequest apiTokenRequest = new() { CustomerId = Configuration.CustomerId, Key = Configuration.Key, Secret = Configuration.Secret };
 
             String apiTokenRequestSerialised = JsonConvert.SerializeObject(apiTokenRequest).ToLower();
             StringContent content = new(apiTokenRequestSerialised, Encoding.UTF8, "application/json");
 
             // First do the authentication
-            HttpResponseMessage apiTokenHttpResponse = await this.HttpClient.PostAsync($"{ConfigurationReader.GetValue(TheSMSWorksBaseAddressKey)}auth/token", content, cancellationToken);
+            HttpResponseMessage apiTokenHttpResponse = await this.HttpClient.PostAsync($"{Configuration.BaseAddress}auth/token", content, cancellationToken);
 
             if (apiTokenHttpResponse.IsSuccessStatusCode) {
-                TheSmsWorksTokenResponse apiTokenResponse = JsonConvert.DeserializeObject<TheSmsWorksTokenResponse>(await apiTokenHttpResponse.Content.ReadAsStringAsync());
+                TheSmsWorksTokenResponse apiTokenResponse = JsonConvert.DeserializeObject<TheSmsWorksTokenResponse>(await apiTokenHttpResponse.Content.ReadAsStringAsync(cancellationToken));
 
                 // Now do the actual send
                 TheSmsWorksSendSMSRequest apiSendSmsRequest = new() {
@@ -73,11 +76,11 @@ namespace MessagingService.BusinessLogic.Services.SMSServices.TheSMSWorks
                 content = new StringContent(apiSendSMSMessageRequestSerialised, Encoding.UTF8, "application/json");
 
                 this.HttpClient.DefaultRequestHeaders.Add("Authorization", apiTokenResponse.Token);
-                HttpResponseMessage apiSendSMSMessageHttpResponse = await this.HttpClient.PostAsync($"{ConfigurationReader.GetValue(TheSMSWorksBaseAddressKey)}message/send", content, cancellationToken);
+                HttpResponseMessage apiSendSMSMessageHttpResponse = await this.HttpClient.PostAsync($"{Configuration.BaseAddress}message/send", content, cancellationToken);
 
                 if (apiSendSMSMessageHttpResponse.IsSuccessStatusCode) {
                     // Message has been sent
-                    TheSmsWorksSendSMSResponse apiTheSmsWorksSendSmsResponse = JsonConvert.DeserializeObject<TheSmsWorksSendSMSResponse>(await apiSendSMSMessageHttpResponse.Content.ReadAsStringAsync());
+                    TheSmsWorksSendSMSResponse apiTheSmsWorksSendSmsResponse = JsonConvert.DeserializeObject<TheSmsWorksSendSMSResponse>(await apiSendSMSMessageHttpResponse.Content.ReadAsStringAsync(cancellationToken));
 
                     response = new SMSServiceProxyResponse { ApiCallSuccessful = true, SMSIdentifier = apiTheSmsWorksSendSmsResponse.MessageId, };
                 }
@@ -97,26 +100,23 @@ namespace MessagingService.BusinessLogic.Services.SMSServices.TheSMSWorks
             MessageStatusResponse response = new();
 
             // Create the Auth Request                
-            TheSmsWorksTokenRequest apiTokenRequest = new() { CustomerId = ConfigurationReader.GetValue(TheSMSWorksCustomerIdKey),
-                Key = ConfigurationReader.GetValue(TheSMSWorksKeyKey),
-                Secret = ConfigurationReader.GetValue(TheSMSWorksSecretKey)
-            };
+            TheSmsWorksTokenRequest apiTokenRequest = new() { CustomerId = Configuration.CustomerId, Key = Configuration.Key, Secret = Configuration.Secret };
 
             String apiTokenRequestSerialised = JsonConvert.SerializeObject(apiTokenRequest).ToLower();
             StringContent content = new(apiTokenRequestSerialised, Encoding.UTF8, "application/json");
 
             // First do the authentication
-            HttpResponseMessage apiTokenHttpResponse = await this.HttpClient.PostAsync($"{ConfigurationReader.GetValue(TheSMSWorksBaseAddressKey)}auth/token", content, cancellationToken);
+            HttpResponseMessage apiTokenHttpResponse = await this.HttpClient.PostAsync($"{Configuration.BaseAddress}auth/token", content, cancellationToken);
 
             if (apiTokenHttpResponse.IsSuccessStatusCode) {
                 TheSmsWorksTokenResponse apiTokenResponse = JsonConvert.DeserializeObject<TheSmsWorksTokenResponse>(await apiTokenHttpResponse.Content.ReadAsStringAsync(cancellationToken));
 
                 this.HttpClient.DefaultRequestHeaders.Add("Authorization", apiTokenResponse.Token);
-                HttpResponseMessage apiGetSMSMessageHttpResponse = await this.HttpClient.GetAsync($"{ConfigurationReader.GetValue(TheSMSWorksBaseAddressKey)}messages/{providerReference}", cancellationToken);
+                HttpResponseMessage apiGetSMSMessageHttpResponse = await this.HttpClient.GetAsync($"{Configuration.BaseAddress}messages/{providerReference}", cancellationToken);
 
                 if (apiGetSMSMessageHttpResponse.IsSuccessStatusCode) {
                     // Message has been sent
-                    TheSMSWorksGetMessageResponse apiSmsWorksGetMessageResponse = JsonConvert.DeserializeObject<TheSMSWorksGetMessageResponse>(await apiGetSMSMessageHttpResponse.Content.ReadAsStringAsync());
+                    TheSMSWorksGetMessageResponse apiSmsWorksGetMessageResponse = JsonConvert.DeserializeObject<TheSMSWorksGetMessageResponse>(await apiGetSMSMessageHttpResponse.Content.ReadAsStringAsync(cancellationToken));
 
                     response = new MessageStatusResponse { ApiStatusCode = apiGetSMSMessageHttpResponse.StatusCode, MessageStatus = this.TranslateMessageStatus(apiSmsWorksGetMessageResponse.Status), ProviderStatusDescription = apiSmsWorksGetMessageResponse.Status, Timestamp = DateTime.Parse(apiSmsWorksGetMessageResponse.Modified) };
                 }

--- a/MessagingService/Bootstrapper/MessagingProxyRegistry.cs
+++ b/MessagingService/Bootstrapper/MessagingProxyRegistry.cs
@@ -5,7 +5,9 @@ using BusinessLogic.Services.EmailServices.Smtp2Go;
 using BusinessLogic.Services.SMSServices;
 using BusinessLogic.Services.SMSServices.TheSMSWorks;
 using ClientProxyBase;
+using Google.Api;
 using Lamar;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Service.Services.Email.IntegrationTest;
 using Service.Services.SMSServices.IntegrationTest;
@@ -34,6 +36,11 @@ public class MessagingProxyRegistry : ServiceRegistry
 
         if (emailProxy == "Smtp2Go")
         {
+            Smtp2GConfig config = Startup.Configuration
+                                      .GetSection("AppSettings:Smtp2Go")
+                                      .Get<Smtp2GConfig>()
+                                  ?? throw new InvalidOperationException("Smtp2Go config missing"); ;
+            this.AddSingleton(config);
             this.RegisterHttpClient<IEmailServiceProxy, Smtp2GoProxy>();
         }
         else
@@ -45,10 +52,14 @@ public class MessagingProxyRegistry : ServiceRegistry
     private void RegisterSMSProxy()
     {
         // read the config setting 
-        String emailProxy = ConfigurationReader.GetValue("AppSettings", "SMSProxy");
+        String smsProxy = ConfigurationReader.GetValue("AppSettings", "SMSProxy");
 
-        if (emailProxy == "TheSMSWorks")
-        {
+        if (smsProxy == "TheSMSWorks") {
+            SmsWorksConfig config = Startup.Configuration
+                                        .GetSection("AppSettings:TheSmsWorks")
+                                        .Get<SmsWorksConfig>()
+                                    ?? throw new InvalidOperationException("SmsWorks config missing"); ;
+            this.AddSingleton(config);
             this.RegisterHttpClient<ISMSServiceProxy, TheSmsWorksProxy>();
         }
         else

--- a/MessagingService/Bootstrapper/MessagingProxyRegistry.cs
+++ b/MessagingService/Bootstrapper/MessagingProxyRegistry.cs
@@ -29,41 +29,30 @@ public class MessagingProxyRegistry : ServiceRegistry
         this.RegisterSMSProxy();
     }
 
-    private void RegisterEmailProxy()
-    {
+    private void RegisterEmailProxy() {
         // read the config setting 
         String emailProxy = ConfigurationReader.GetValue("AppSettings", "EmailProxy");
 
-        if (emailProxy == "Smtp2Go")
-        {
-            Smtp2GConfig config = Startup.Configuration
-                                      .GetSection("AppSettings:Smtp2Go")
-                                      .Get<Smtp2GConfig>()
-                                  ?? throw new InvalidOperationException("Smtp2Go config missing"); ;
+        if (emailProxy == "Smtp2Go") {
+            Smtp2GConfig config = Startup.Configuration.GetSection("AppSettings:Smtp2Go").Get<Smtp2GConfig>() ?? throw new InvalidOperationException("Smtp2Go config missing");
             this.AddSingleton(config);
             this.RegisterHttpClient<IEmailServiceProxy, Smtp2GoProxy>();
         }
-        else
-        {
+        else {
             this.AddSingleton<IEmailServiceProxy, IntegrationTestEmailServiceProxy>();
         }
     }
 
-    private void RegisterSMSProxy()
-    {
+    private void RegisterSMSProxy() {
         // read the config setting 
         String smsProxy = ConfigurationReader.GetValue("AppSettings", "SMSProxy");
 
         if (smsProxy == "TheSMSWorks") {
-            SmsWorksConfig config = Startup.Configuration
-                                        .GetSection("AppSettings:TheSmsWorks")
-                                        .Get<SmsWorksConfig>()
-                                    ?? throw new InvalidOperationException("SmsWorks config missing"); ;
+            SmsWorksConfig config = Startup.Configuration.GetSection("AppSettings:TheSmsWorks").Get<SmsWorksConfig>() ?? throw new InvalidOperationException("SmsWorks config missing");
             this.AddSingleton(config);
             this.RegisterHttpClient<ISMSServiceProxy, TheSmsWorksProxy>();
         }
-        else
-        {
+        else {
             this.AddSingleton<ISMSServiceProxy, IntegrationTestSMSServiceProxy>();
         }
     }

--- a/MessagingService/appsettings.json
+++ b/MessagingService/appsettings.json
@@ -21,12 +21,16 @@
     },
     "EmailProxy": "Smtp2Go",
     "SMSProxy": "TheSMSWorks",
-    "SMTP2GoBaseAddress": "https://api.smtp2go.com/v3/",    
-    "SMTP2GoAPIKey": "api-FC9777E0E53611E6A2F3F23C91BBF4A0",
-    "TheSMSWorksBaseAddress": "https://api.thesmsworks.co.uk/v1/",
-    "TheSMSWorksCustomerId": "5400-d666-5990-402f-aa48-a1fa9f45fd02",
-    "TheSMSWorksKey": "55f1d327-f759-44aa-b535-208bd2c934c8",
-    "TheSMSWorksSecret": "5e832a0b1cf3d9cd08e2808e3535e204bd7ec20ba2cb17a1930cd4986cf208ef",
+    "Smtp2Go": {
+      "BaseAddress": "https://api.smtp2go.com/v3/",
+      "APIKey": "api-FC9777E0E53611E6A2F3F23C91BBF4A0"
+    },
+    "TheSmsWorks": {
+      "BaseAddress": "https://api.thesmsworks.co.uk/v1/",
+      "CustomerId": "5400-d666-5990-402f-aa48-a1fa9f45fd02",
+      "Key": "55f1d327-f759-44aa-b535-208bd2c934c8",
+      "Secret": "5e832a0b1cf3d9cd08e2808e3535e204bd7ec20ba2cb17a1930cd4986cf208ef"
+    },
     "EventHandlerConfiguration": {
       "MessagingService.BusinessLogic.EventHandling.EmailDomainEventHandler, MessagingService.BusinessLogic": [
         "ResponseReceivedFromEmailProviderEvent"


### PR DESCRIPTION
Moved SMTP2Go and TheSMSWorks configuration from flat appsettings.json keys to nested objects, introducing Smtp2GConfig and SmsWorksConfig record types. Updated proxies to use constructor injection for config, removed direct ConfigurationReader usage, and registered config objects in DI. Cleaned up MessagingProxyRegistry and updated appsettings.json accordingly. Minor improvements to async calls and code clarity.

closes #376 