### PR TITLE
Refactor: replace Newtonsoft.Json with StringSerialiser

### DIFF
--- a/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Data.cs
+++ b/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Data.cs
@@ -3,30 +3,16 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
+    
     /// <summary>
     /// 
     /// </summary>
     [ExcludeFromCodeCoverage]
     public class Data
     {
-        /// <summary>
-        /// Gets or sets the count.
-        /// </summary>
-        /// <value>
-        /// The count.
-        /// </value>
-        [JsonProperty("count")]
+
         public Int32 Count { get; set; }
 
-        /// <summary>
-        /// Gets or sets the email details.
-        /// </summary>
-        /// <value>
-        /// The email details.
-        /// </value>
-        [JsonProperty("emails")]
         public List<EmailDetails> EmailDetails { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/EmailDetails.cs
+++ b/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/EmailDetails.cs
@@ -2,66 +2,20 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
 
-    /// <summary>
-    /// 
-    /// </summary>
     [ExcludeFromCodeCoverage]
     public class EmailDetails
     {
-        /// <summary>
-        /// Gets or sets the subject.
-        /// </summary>
-        /// <value>
-        /// The subject.
-        /// </value>
-        [JsonProperty("subject")]
         public String Subject { get; set; }
 
-        /// <summary>
-        /// Gets or sets the delivered at.
-        /// </summary>
-        /// <value>
-        /// The delivered at.
-        /// </value>
-        [JsonProperty("delivered_at")]
         public DateTime DeliveredAt { get; set; }
 
-        /// <summary>
-        /// Gets or sets the email status date.
-        /// </summary>
-        /// <value>
-        /// The email status date.
-        /// </value>
-        [JsonProperty("email_ts")]
         public DateTime EmailStatusDate { get; set; }
 
-        /// <summary>
-        /// Gets or sets the process status.
-        /// </summary>
-        /// <value>
-        /// The process status.
-        /// </value>
-        [JsonProperty("process_status")]
         public String ProcessStatus { get; set; }
 
-        /// <summary>
-        /// Gets or sets the email identifier.
-        /// </summary>
-        /// <value>
-        /// The email identifier.
-        /// </value>
-        [JsonProperty("email_id")]
         public String EmailId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the status.
-        /// </summary>
-        /// <value>
-        /// The status.
-        /// </value>
-        [JsonProperty("status")]
         public String Status { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoAttachment.cs
+++ b/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoAttachment.cs
@@ -2,23 +2,14 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
-
+    
     [ExcludeFromCodeCoverage]
     public class Smtp2GoAttachment
     {
-        #region Properties
-
-        [JsonProperty("fileblob")]
         public String FileBlob { get; set; }
 
-        [JsonProperty("filename")]
         public String FileName { get; set; }
 
-        [JsonProperty("mimetype")]
         public String MimeType { get; set; }
-
-        #endregion
     }
 }

--- a/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoEmailSearchRequest.cs
+++ b/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoEmailSearchRequest.cs
@@ -3,48 +3,16 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
-    /// <summary>
-    /// 
-    /// </summary>
+    
     [ExcludeFromCodeCoverage]
     public class Smtp2GoEmailSearchRequest
     {
-        /// <summary>
-        /// Gets or sets the email identifier.
-        /// </summary>
-        /// <value>
-        /// The email identifier.
-        /// </value>
-        [JsonProperty("email_id")]
         public List<String> EmailId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the API key.
-        /// </summary>
-        /// <value>
-        /// The API key.
-        /// </value>
-        [JsonProperty("api_key")]
         public String ApiKey { get; set; }
 
-        /// <summary>
-        /// Gets or sets the start date.
-        /// </summary>
-        /// <value>
-        /// The start date.
-        /// </value>
-        [JsonProperty("start_date")]
         public String StartDate { get; set; }
 
-        /// <summary>
-        /// Gets or sets the end date.
-        /// </summary>
-        /// <value>
-        /// The end date.
-        /// </value>
-        [JsonProperty("end_date")]
         public String EndDate { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoEmailSearchResponse.cs
+++ b/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoEmailSearchResponse.cs
@@ -2,34 +2,12 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
-    /// <summary>
-    /// 
-    /// </summary>
+    
     [ExcludeFromCodeCoverage]
     public class Smtp2GoEmailSearchResponse
     {
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the data.
-        /// </summary>
-        /// <value>
-        /// The data.
-        /// </value>
-        [JsonProperty("data")]
         public Data Data { get; set; }
 
-        /// <summary>
-        /// Gets or sets the request identifier.
-        /// </summary>
-        /// <value>
-        /// The request identifier.
-        /// </value>
-        [JsonProperty("request_id")]
         public String RequestId { get; set; }
-
-        #endregion
     }
 }

--- a/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoProxy.cs
+++ b/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoProxy.cs
@@ -1,16 +1,15 @@
-﻿namespace MessagingService.BusinessLogic.Services.EmailServices.Smtp2Go
+﻿using Shared.Serialisation;
+
+namespace MessagingService.BusinessLogic.Services.EmailServices.Smtp2Go
 {
     using Models;
-    using Newtonsoft.Json;
     using Service.Services.Email.Smtp2Go;
-    using Shared.General;
     using Shared.Logger;
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
     using System.Linq;
     using System.Net.Http;
-    using System.Reflection;
     using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
@@ -73,7 +72,7 @@
                 attachments.ForEach(a => apiRequest.Attachments.Add(new Smtp2GoAttachment { FileBlob = a.FileData, FileName = a.Filename, MimeType = this.ConvertFileType(a.FileType) }));
             }
 
-            String requestSerialised = JsonConvert.SerializeObject(apiRequest, Formatting.Indented, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None });
+            String requestSerialised = StringSerialiser.Serialise(apiRequest, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase, WriteIndented:true));
 
             Logger.LogDebug($"Request Message Sent to Email Provider [SMTP2Go] {requestSerialised}");
 
@@ -86,12 +85,11 @@
             HttpResponseMessage httpResponse = await this.HttpClient.SendAsync(requestMessage, cancellationToken);
 
             Smtp2GoSendEmailResponse apiResponse = httpResponse.IsSuccessStatusCode switch {
-                true => JsonConvert.DeserializeObject<Smtp2GoSendEmailResponse>(await httpResponse.Content.ReadAsStringAsync(cancellationToken)),
+                true => StringSerialiser.Deserialise<Smtp2GoSendEmailResponse>(await httpResponse.Content.ReadAsStringAsync(cancellationToken)),
                 _ => new Smtp2GoSendEmailResponse { Data = new Smtp2GoSendEmailResponseData { Error = httpResponse.StatusCode.ToString(), ErrorCode = ((Int32)httpResponse.StatusCode).ToString() } }
             };
 
-            Logger.LogDebug($"Response Message Received from Email Provider [SMTP2Go] {JsonConvert.SerializeObject(apiResponse)}");
-
+            Logger.LogDebug($"Response Message Received from Email Provider [SMTP2Go] {StringSerialiser.Serialise(apiResponse)}");
             // Translate the Response
             return new EmailServiceProxyResponse {
                 ApiCallSuccessful = httpResponse.IsSuccessStatusCode && String.IsNullOrEmpty(apiResponse.Data.ErrorCode),
@@ -119,7 +117,7 @@
                 ApiKey = Configuration.APIKey, EmailId = new List<String> { providerReference }, StartDate = startDate.ToString("yyyy-MM-dd"), EndDate = endDate.ToString("yyyy-MM-dd"),
             };
 
-            String requestSerialised = JsonConvert.SerializeObject(apiRequest, new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.None });
+            String requestSerialised = StringSerialiser.Serialise(apiRequest, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase, WriteIndented: true));
 
             Logger.LogDebug($"Request Message Sent to Email Provider [SMTP2Go] {requestSerialised}");
 
@@ -131,9 +129,9 @@
 
             HttpResponseMessage httpResponse = await this.HttpClient.SendAsync(requestMessage, cancellationToken);
 
-            Smtp2GoEmailSearchResponse apiResponse = JsonConvert.DeserializeObject<Smtp2GoEmailSearchResponse>(await httpResponse.Content.ReadAsStringAsync(cancellationToken));
+            Smtp2GoEmailSearchResponse apiResponse = StringSerialiser.Deserialise<Smtp2GoEmailSearchResponse>(await httpResponse.Content.ReadAsStringAsync(cancellationToken));
 
-            Logger.LogDebug($"Response Message Received from Email Provider [SMTP2Go] {JsonConvert.SerializeObject(apiResponse)}");
+            Logger.LogDebug($"Response Message Received from Email Provider [SMTP2Go] {StringSerialiser.Serialise(apiResponse)}");
 
             // Translate the Response
             return new MessageStatusResponse { ApiStatusCode = httpResponse.StatusCode, MessageStatus = this.TranslateMessageStatus(apiResponse.Data.EmailDetails.Single().Status), ProviderStatusDescription = apiResponse.Data.EmailDetails.Single().Status, Timestamp = apiResponse.Data.EmailDetails.Single().EmailStatusDate };

--- a/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoSendEmailRequest.cs
+++ b/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoSendEmailRequest.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Newtonsoft.Json;
 
 namespace MessagingService.Service.Services.Email.Smtp2Go
 {
@@ -9,95 +8,24 @@ namespace MessagingService.Service.Services.Email.Smtp2Go
     [ExcludeFromCodeCoverage]
     public class Smtp2GoSendEmailRequest
     {
-        /// <summary>
-        /// Gets or sets the API key.
-        /// </summary>
-        /// <value>
-        /// The API key.
-        /// </value>
-        [JsonProperty("api_key")]
         public String ApiKey { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether [test mode].
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if [test mode]; otherwise, <c>false</c>.
-        /// </value>
-        [JsonProperty("test")]
         public Boolean TestMode { get; set; }
 
-        /// <summary>
-        /// Gets or sets the sender.
-        /// </summary>
-        /// <value>
-        /// The sender.
-        /// </value>
-        [JsonProperty("sender")]
         public String Sender { get; set; }
 
-        /// <summary>
-        /// Gets or sets to.
-        /// </summary>
-        /// <value>
-        /// To.
-        /// </value>
-        [JsonProperty("to")]
         public String[] To { get; set; }
 
-        /// <summary>
-        /// Gets or sets the cc.
-        /// </summary>
-        /// <value>
-        /// The cc.
-        /// </value>
-        [JsonProperty("cc")]
         public String[] CC { get; set; }
 
-        /// <summary>
-        /// Gets or sets the BCC.
-        /// </summary>
-        /// <value>
-        /// The BCC.
-        /// </value>
-        [JsonProperty("bcc")]
         public String[] BCC { get; set; }
 
-        /// <summary>
-        /// Gets or sets the subject.
-        /// </summary>
-        /// <value>
-        /// The subject.
-        /// </value>
-        [JsonProperty("subject")]
         public String Subject { get; set; }
 
-        /// <summary>
-        /// Gets or sets the HTML body.
-        /// </summary>
-        /// <value>
-        /// The HTML body.
-        /// </value>
-        [JsonProperty("html_body")]
         public String HTMLBody { get; set; }
 
-        /// <summary>
-        /// Gets or sets the text body.
-        /// </summary>
-        /// <value>
-        /// The text body.
-        /// </value>
-        [JsonProperty("text_body")]
         public String TextBody { get; set; }
 
-        /// <summary>
-        /// Gets or sets the attachments.
-        /// </summary>
-        /// <value>
-        /// The attachments.
-        /// </value>
-        [JsonProperty("attachments")]
         public List<Smtp2GoAttachment> Attachments { get; set; }
-
     }
 }

--- a/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoSendEmailResponse.cs
+++ b/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoSendEmailResponse.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Newtonsoft.Json;
 
 namespace MessagingService.Service.Services.Email.Smtp2Go
 {
@@ -8,22 +7,8 @@ namespace MessagingService.Service.Services.Email.Smtp2Go
     [ExcludeFromCodeCoverage]
     public class Smtp2GoSendEmailResponse
     {
-        /// <summary>
-        /// Gets or sets the request identifier.
-        /// </summary>
-        /// <value>
-        /// The request identifier.
-        /// </value>
-        [JsonProperty("request_id")]
         public String RequestId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the data.
-        /// </summary>
-        /// <value>
-        /// The data.
-        /// </value>
-        [JsonProperty("data")]
         public Smtp2GoSendEmailResponseData Data { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoSendEmailResponseData.cs
+++ b/MessagingService.BusinessLogic/Services/EmailServices/Smtp2Go/Smtp2GoSendEmailResponseData.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using Newtonsoft.Json;
 
 namespace MessagingService.Service.Services.Email.Smtp2Go
 {
@@ -8,58 +7,16 @@ namespace MessagingService.Service.Services.Email.Smtp2Go
     [ExcludeFromCodeCoverage]
     public class Smtp2GoSendEmailResponseData
     {
-        /// <summary>
-        /// Gets or sets the failed.
-        /// </summary>
-        /// <value>
-        /// The failed.
-        /// </value>
-        [JsonProperty("failed")]
         public Int32 Failed { get; set; }
 
-        /// <summary>
-        /// Gets or sets the failures.
-        /// </summary>
-        /// <value>
-        /// The failures.
-        /// </value>
-        [JsonProperty("failures")]
         public String[] Failures { get; set; }
 
-        /// <summary>
-        /// Gets or sets the email identifier.
-        /// </summary>
-        /// <value>
-        /// The email identifier.
-        /// </value>
-        [JsonProperty("email_id")]
         public String EmailId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the succeesful.
-        /// </summary>
-        /// <value>
-        /// The succeesful.
-        /// </value>
-        [JsonProperty("succeeded")]
         public Int32 Succeesful { get; set; }
 
-        /// <summary>
-        /// Gets or sets the error.
-        /// </summary>
-        /// <value>
-        /// The error.
-        /// </value>
-        [JsonProperty("error")]
         public String Error { get; set; }
 
-        /// <summary>
-        /// Gets or sets the error code.
-        /// </summary>
-        /// <value>
-        /// The error code.
-        /// </value>
-        [JsonProperty("error_code")]
         public String ErrorCode { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSMSWorksFailureReason.cs
+++ b/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSMSWorksFailureReason.cs
@@ -2,39 +2,14 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
-    /// <summary>
-    /// 
-    /// </summary>
+    
     [ExcludeFromCodeCoverage]
     public class TheSMSWorksFailureReason
     {
-        /// <summary>
-        /// Gets or sets the code.
-        /// </summary>
-        /// <value>
-        /// The code.
-        /// </value>
-        [JsonProperty("code")]
         public Int32 Code { get; set; }
 
-        /// <summary>
-        /// Gets or sets the details.
-        /// </summary>
-        /// <value>
-        /// The details.
-        /// </value>
-        [JsonProperty("details")]
         public String Details { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether this <see cref="TheSMSWorksFailureReason"/> is permanent.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if permanent; otherwise, <c>false</c>.
-        /// </value>
-        [JsonProperty("permanent")]
         public Boolean Permanent { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSMSWorksGetMessageResponse.cs
+++ b/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSMSWorksGetMessageResponse.cs
@@ -2,156 +2,39 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
 
-    /// <summary>
-    /// 
-    /// </summary>
     [ExcludeFromCodeCoverage]
     public class TheSMSWorksGetMessageResponse
     {
-        /// <summary>
-        /// Gets or sets the batch identifier.
-        /// </summary>
-        /// <value>
-        /// The batch identifier.
-        /// </value>
-        [JsonProperty("batchid")]
         public String BatchId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the content.
-        /// </summary>
-        /// <value>
-        /// The content.
-        /// </value>
-        [JsonProperty("content")]
         public String Content { get; set; }
 
-        /// <summary>
-        /// Gets or sets the created.
-        /// </summary>
-        /// <value>
-        /// The created.
-        /// </value>
-        [JsonProperty("created")]
         public String Created { get; set; }
 
-        /// <summary>
-        /// Gets or sets the customerid.
-        /// </summary>
-        /// <value>
-        /// The customerid.
-        /// </value>
-        [JsonProperty("customerid")]
         public String Customerid { get; set; }
 
-        /// <summary>
-        /// Gets or sets the deliveryreporturl.
-        /// </summary>
-        /// <value>
-        /// The deliveryreporturl.
-        /// </value>
-        [JsonProperty("deliveryreporturl")]
         public String Deliveryreporturl { get; set; }
 
-        /// <summary>
-        /// Gets or sets the destination.
-        /// </summary>
-        /// <value>
-        /// The destination.
-        /// </value>
-        [JsonProperty("destination")]
         public String Destination { get; set; }
 
-        /// <summary>
-        /// Gets or sets the failurereason.
-        /// </summary>
-        /// <value>
-        /// The failurereason.
-        /// </value>
-        [JsonProperty("failurereason")]
         public TheSMSWorksFailureReason Failurereason { get; set; }
 
-        /// <summary>
-        /// Gets or sets the identifier.
-        /// </summary>
-        /// <value>
-        /// The identifier.
-        /// </value>
-        [JsonProperty("id")]
         public String Id { get; set; }
 
-        /// <summary>
-        /// Gets or sets the identifier.
-        /// </summary>
-        /// <value>
-        /// The identifier.
-        /// </value>
-        [JsonProperty("identifier")]
         public String Identifier { get; set; }
 
-        /// <summary>
-        /// Gets or sets the keyword.
-        /// </summary>
-        /// <value>
-        /// The keyword.
-        /// </value>
-        [JsonProperty("keyword")]
         public String Keyword { get; set; }
 
-        /// <summary>
-        /// Gets or sets the messageid.
-        /// </summary>
-        /// <value>
-        /// The messageid.
-        /// </value>
-        [JsonProperty("messageid")]
         public String Messageid { get; set; }
 
-        /// <summary>
-        /// Gets or sets the modified.
-        /// </summary>
-        /// <value>
-        /// The modified.
-        /// </value>
-        [JsonProperty("modified")]
         public String Modified { get; set; }
 
-        /// <summary>
-        /// Gets or sets the schedule.
-        /// </summary>
-        /// <value>
-        /// The schedule.
-        /// </value>
-        [JsonProperty("schedule")]
         public String Schedule { get; set; }
 
-        /// <summary>
-        /// Gets or sets the status.
-        /// </summary>
-        /// <value>
-        /// The status.
-        /// </value>
-        [JsonProperty("status")]
         public String Status { get; set; }
-
-        /// <summary>
-        /// Gets or sets the sender.
-        /// </summary>
-        /// <value>
-        /// The sender.
-        /// </value>
-        [JsonProperty("sender")]
         public String Sender { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tag.
-        /// </summary>
-        /// <value>
-        /// The tag.
-        /// </value>
-        [JsonProperty("tag")]
         public String Tag { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksExtendedErrorModel.cs
+++ b/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksExtendedErrorModel.cs
@@ -2,27 +2,12 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
 
     [ExcludeFromCodeCoverage]
     public class TheSmsWorksExtendedErrorModel
     {
-        /// <summary>
-        /// Gets or sets the message.
-        /// </summary>
-        /// <value>
-        /// The message.
-        /// </value>
-        [JsonProperty("message")]
         public String Message { get; set; }
 
-        /// <summary>
-        /// Gets or sets the errors.
-        /// </summary>
-        /// <value>
-        /// The errors.
-        /// </value>
-        [JsonProperty("errors")]
         public TheSmsWorksExtendedErrorModelError[] Errors { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksExtendedErrorModelError.cs
+++ b/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksExtendedErrorModelError.cs
@@ -2,63 +2,20 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
 
     [ExcludeFromCodeCoverage]
     public class TheSmsWorksExtendedErrorModelError
     {
-        /// <summary>
-        /// Gets or sets the code.
-        /// </summary>
-        /// <value>
-        /// The code.
-        /// </value>
-        [JsonProperty("code")]
         public String Code { get; set; }
 
-        /// <summary>
-        /// Gets or sets the field errors.
-        /// </summary>
-        /// <value>
-        /// The field errors.
-        /// </value>
-        [JsonProperty("errors")]
         public TheSmsWorksExtendedErrorModelFieldError[] FieldErrors { get; set; }
 
-        /// <summary>
-        /// Gets or sets the in.
-        /// </summary>
-        /// <value>
-        /// The in.
-        /// </value>
-        [JsonProperty("in")]
         public String In { get; set; }
 
-        /// <summary>
-        /// Gets or sets the message.
-        /// </summary>
-        /// <value>
-        /// The message.
-        /// </value>
-        [JsonProperty("message")]
         public String Message { get; set; }
 
-        /// <summary>
-        /// Gets or sets the name.
-        /// </summary>
-        /// <value>
-        /// The name.
-        /// </value>
-        [JsonProperty("name")]
         public String Name { get; set; }
 
-        /// <summary>
-        /// Gets or sets the path.
-        /// </summary>
-        /// <value>
-        /// The path.
-        /// </value>
-        [JsonProperty("path")]
         public String[] Path { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksExtendedErrorModelFieldError.cs
+++ b/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksExtendedErrorModelFieldError.cs
@@ -2,48 +2,18 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
+    
     [ExcludeFromCodeCoverage]
     public class TheSmsWorksExtendedErrorModelFieldError
     {
-        [JsonProperty("code")]
         public String Code { get; set; }
 
-        /// <summary>
-        /// Gets or sets the parameters.
-        /// </summary>
-        /// <value>
-        /// The parameters.
-        /// </value>
-        [JsonProperty("params")]
         public String[] Params { get; set; }
 
-        /// <summary>
-        /// Gets or sets the message.
-        /// </summary>
-        /// <value>
-        /// The message.
-        /// </value>
-        [JsonProperty("message")]
         public String Message { get; set; }
 
-        /// <summary>
-        /// Gets or sets the path.
-        /// </summary>
-        /// <value>
-        /// The path.
-        /// </value>
-        [JsonProperty("path")]
         public String[] Path { get; set; }
 
-        /// <summary>
-        /// Gets or sets the description.
-        /// </summary>
-        /// <value>
-        /// The description.
-        /// </value>
-        [JsonProperty("description")]
         public String Description { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksProxy.cs
+++ b/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksProxy.cs
@@ -1,7 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Security.Authentication;
 using System.Text;
+using Shared.Serialisation;
 
 namespace MessagingService.BusinessLogic.Services.SMSServices.TheSMSWorks
 {
@@ -10,11 +10,8 @@ namespace MessagingService.BusinessLogic.Services.SMSServices.TheSMSWorks
     using System.Net.Http;
     using System.Threading;
     using System.Threading.Tasks;
-    using Newtonsoft.Json;
-    using Requests;
     using Shared.Exceptions;
     using Shared.Extensions;
-    using Shared.General;
 
     public record SmsWorksConfig {
         public String BaseAddress { get; set; }
@@ -53,14 +50,14 @@ namespace MessagingService.BusinessLogic.Services.SMSServices.TheSMSWorks
             // Create the Auth Request                
             TheSmsWorksTokenRequest apiTokenRequest = new() { CustomerId = Configuration.CustomerId, Key = Configuration.Key, Secret = Configuration.Secret };
 
-            String apiTokenRequestSerialised = JsonConvert.SerializeObject(apiTokenRequest).ToLower();
+            String apiTokenRequestSerialised = StringSerialiser.Serialise(apiTokenRequest).ToLower();
             StringContent content = new(apiTokenRequestSerialised, Encoding.UTF8, "application/json");
 
             // First do the authentication
             HttpResponseMessage apiTokenHttpResponse = await this.HttpClient.PostAsync($"{Configuration.BaseAddress}auth/token", content, cancellationToken);
 
             if (apiTokenHttpResponse.IsSuccessStatusCode) {
-                TheSmsWorksTokenResponse apiTokenResponse = JsonConvert.DeserializeObject<TheSmsWorksTokenResponse>(await apiTokenHttpResponse.Content.ReadAsStringAsync(cancellationToken));
+                TheSmsWorksTokenResponse apiTokenResponse = StringSerialiser.Deserialise<TheSmsWorksTokenResponse>(await apiTokenHttpResponse.Content.ReadAsStringAsync(cancellationToken));
 
                 // Now do the actual send
                 TheSmsWorksSendSMSRequest apiSendSmsRequest = new() {
@@ -72,7 +69,7 @@ namespace MessagingService.BusinessLogic.Services.SMSServices.TheSMSWorks
                     Ttl = 0
                 };
 
-                String apiSendSMSMessageRequestSerialised = JsonConvert.SerializeObject(apiSendSmsRequest).ToLower();
+                String apiSendSMSMessageRequestSerialised = StringSerialiser.Serialise(apiSendSmsRequest).ToLower();
                 content = new StringContent(apiSendSMSMessageRequestSerialised, Encoding.UTF8, "application/json");
 
                 this.HttpClient.DefaultRequestHeaders.Add("Authorization", apiTokenResponse.Token);
@@ -80,7 +77,7 @@ namespace MessagingService.BusinessLogic.Services.SMSServices.TheSMSWorks
 
                 if (apiSendSMSMessageHttpResponse.IsSuccessStatusCode) {
                     // Message has been sent
-                    TheSmsWorksSendSMSResponse apiTheSmsWorksSendSmsResponse = JsonConvert.DeserializeObject<TheSmsWorksSendSMSResponse>(await apiSendSMSMessageHttpResponse.Content.ReadAsStringAsync(cancellationToken));
+                    TheSmsWorksSendSMSResponse apiTheSmsWorksSendSmsResponse = StringSerialiser.Deserialise<TheSmsWorksSendSMSResponse>(await apiSendSMSMessageHttpResponse.Content.ReadAsStringAsync(cancellationToken));
 
                     response = new SMSServiceProxyResponse { ApiCallSuccessful = true, SMSIdentifier = apiTheSmsWorksSendSmsResponse.MessageId, };
                 }
@@ -102,21 +99,21 @@ namespace MessagingService.BusinessLogic.Services.SMSServices.TheSMSWorks
             // Create the Auth Request                
             TheSmsWorksTokenRequest apiTokenRequest = new() { CustomerId = Configuration.CustomerId, Key = Configuration.Key, Secret = Configuration.Secret };
 
-            String apiTokenRequestSerialised = JsonConvert.SerializeObject(apiTokenRequest).ToLower();
+            String apiTokenRequestSerialised = StringSerialiser.Serialise(apiTokenRequest).ToLower();
             StringContent content = new(apiTokenRequestSerialised, Encoding.UTF8, "application/json");
 
             // First do the authentication
             HttpResponseMessage apiTokenHttpResponse = await this.HttpClient.PostAsync($"{Configuration.BaseAddress}auth/token", content, cancellationToken);
 
             if (apiTokenHttpResponse.IsSuccessStatusCode) {
-                TheSmsWorksTokenResponse apiTokenResponse = JsonConvert.DeserializeObject<TheSmsWorksTokenResponse>(await apiTokenHttpResponse.Content.ReadAsStringAsync(cancellationToken));
+                TheSmsWorksTokenResponse apiTokenResponse = StringSerialiser.Deserialise<TheSmsWorksTokenResponse>(await apiTokenHttpResponse.Content.ReadAsStringAsync(cancellationToken));
 
                 this.HttpClient.DefaultRequestHeaders.Add("Authorization", apiTokenResponse.Token);
                 HttpResponseMessage apiGetSMSMessageHttpResponse = await this.HttpClient.GetAsync($"{Configuration.BaseAddress}messages/{providerReference}", cancellationToken);
 
                 if (apiGetSMSMessageHttpResponse.IsSuccessStatusCode) {
                     // Message has been sent
-                    TheSMSWorksGetMessageResponse apiSmsWorksGetMessageResponse = JsonConvert.DeserializeObject<TheSMSWorksGetMessageResponse>(await apiGetSMSMessageHttpResponse.Content.ReadAsStringAsync(cancellationToken));
+                    TheSMSWorksGetMessageResponse apiSmsWorksGetMessageResponse = StringSerialiser.Deserialise<TheSMSWorksGetMessageResponse>(await apiGetSMSMessageHttpResponse.Content.ReadAsStringAsync(cancellationToken));
 
                     response = new MessageStatusResponse { ApiStatusCode = apiGetSMSMessageHttpResponse.StatusCode, MessageStatus = this.TranslateMessageStatus(apiSmsWorksGetMessageResponse.Status), ProviderStatusDescription = apiSmsWorksGetMessageResponse.Status, Timestamp = DateTime.Parse(apiSmsWorksGetMessageResponse.Modified) };
                 }

--- a/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksSendSMSRequest.cs
+++ b/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksSendSMSRequest.cs
@@ -2,63 +2,20 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
 
     [ExcludeFromCodeCoverage]
     public class TheSmsWorksSendSMSRequest
     {
-        /// <summary>
-        /// Gets or sets the sender.
-        /// </summary>
-        /// <value>
-        /// The sender.
-        /// </value>
-        [JsonProperty("sender")]
         public String Sender { get; set; }
 
-        /// <summary>
-        /// Gets or sets the destination.
-        /// </summary>
-        /// <value>
-        /// The destination.
-        /// </value>
-        [JsonProperty("destination")]
         public String Destination { get; set; }
 
-        /// <summary>
-        /// Gets or sets the content.
-        /// </summary>
-        /// <value>
-        /// The content.
-        /// </value>
-        [JsonProperty("content")]
         public String Content { get; set; }
 
-        /// <summary>
-        /// Gets or sets the schedule.
-        /// </summary>
-        /// <value>
-        /// The schedule.
-        /// </value>
-        [JsonProperty("schedule")]
         public String Schedule { get; set; }
 
-        /// <summary>
-        /// Gets or sets the tag.
-        /// </summary>
-        /// <value>
-        /// The tag.
-        /// </value>
-        [JsonProperty("tag")]
         public String Tag { get; set; }
 
-        /// <summary>
-        /// Gets or sets the TTL.
-        /// </summary>
-        /// <value>
-        /// The TTL.
-        /// </value>
-        [JsonProperty("ttl")]
         public Int32 Ttl { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksSendSMSResponse.cs
+++ b/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksSendSMSResponse.cs
@@ -2,36 +2,14 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
+    
     [ExcludeFromCodeCoverage]
     public class TheSmsWorksSendSMSResponse
     {
-        /// <summary>
-        /// Gets or sets the message identifier.
-        /// </summary>
-        /// <value>
-        /// The message identifier.
-        /// </value>
-        [JsonProperty("messageid")]
         public String MessageId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the status.
-        /// </summary>
-        /// <value>
-        /// The status.
-        /// </value>
-        [JsonProperty("status")]
         public String Status { get; set; }
 
-        /// <summary>
-        /// Gets or sets the credits.
-        /// </summary>
-        /// <value>
-        /// The credits.
-        /// </value>
-        [JsonProperty("credits")]
         public Int32 Credits { get; set; }
     }
 }

--- a/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksTokenRequest.cs
+++ b/MessagingService.BusinessLogic/Services/SMSServices/TheSMSWorks/TheSmsWorksTokenRequest.cs
@@ -2,36 +2,14 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
+    
     [ExcludeFromCodeCoverage]
     public class TheSmsWorksTokenRequest
     {
-        /// <summary>
-        /// Gets or sets the customer identifier.
-        /// </summary>
-        /// <value>
-        /// The customer identifier.
-        /// </value>
-        [JsonProperty("customerid")]
         public String CustomerId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the key.
-        /// </summary>
-        /// <value>
-        /// The key.
-        /// </value>
-        [JsonProperty("key")]
         public String Key { get; set; }
 
-        /// <summary>
-        /// Gets or sets the secret.
-        /// </summary>
-        /// <value>
-        /// The secret.
-        /// </value>
-        [JsonProperty("secret")]
         public String Secret { get; set; }
     }
 }

--- a/MessagingService.Client/MessagingService.Client.csproj
+++ b/MessagingService.Client/MessagingService.Client.csproj
@@ -6,9 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
-    <PackageReference Include="Shared.Results" Version="2026.3.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.5.4" />
+    <PackageReference Include="Shared.Results" Version="2026.5.4" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/MessagingService.Client/MessagingServiceClient.cs
+++ b/MessagingService.Client/MessagingServiceClient.cs
@@ -4,13 +4,10 @@ namespace MessagingService.Client
 {
     using System;
     using System.Net.Http;
-    using System.Net.Http.Headers;
-    using System.Text;
     using System.Threading;
     using System.Threading.Tasks;
     using ClientProxyBase;
     using DataTransferObjects;
-    using Newtonsoft.Json;
     using SimpleResults;
 
     public class MessagingServiceClient : ClientProxyBase, IMessagingServiceClient
@@ -26,7 +23,9 @@ namespace MessagingService.Client
         #region Constructors
 
         public MessagingServiceClient(Func<String, String> baseAddressResolver,
-                                      HttpClient httpClient) : base(httpClient)
+                                      HttpClient httpClient,
+                                      Func<object, string> serialise,
+                                      Func<string, Type, object> deserialise) : base(httpClient, serialise, deserialise)
         {
             this.BaseAddressResolver = baseAddressResolver;
         }
@@ -43,7 +42,7 @@ namespace MessagingService.Client
 
             try
             {
-                Result<ResponseData<String>> result = await this.SendHttpPostRequest<SendEmailRequest, ResponseData<String>>(requestUri, sendEmailRequest, accessToken, cancellationToken);
+                Result result = await this.Post(requestUri, sendEmailRequest, accessToken, cancellationToken);
                 
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
@@ -65,7 +64,7 @@ namespace MessagingService.Client
             String requestUri = this.BuildRequestUrl("/api/email/resend");
 
             try {
-                Result<ResponseData<String>> result = await this.SendHttpPostRequest<ResendEmailRequest, ResponseData<String>>(requestUri, resendEmailRequest, accessToken, cancellationToken);
+                Result result = await this.Post(requestUri, resendEmailRequest, accessToken, cancellationToken);
 
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);
@@ -88,7 +87,7 @@ namespace MessagingService.Client
 
             try
             {
-                Result<ResponseData<String>> result = await this.SendHttpPostRequest<SendSMSRequest, ResponseData<String>>(requestUri, sendSMSRequest, accessToken, cancellationToken);
+                Result result = await this.Post(requestUri, sendSMSRequest, accessToken, cancellationToken);
 
                 if (result.IsFailed)
                     return ResultHelpers.CreateFailure(result);

--- a/MessagingService.DataTransferObjects/EmailAttachment.cs
+++ b/MessagingService.DataTransferObjects/EmailAttachment.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
 
     /// <summary>
     /// 
@@ -10,35 +9,10 @@
     [ExcludeFromCodeCoverage]
     public class EmailAttachment
     {
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the file data.
-        /// </summary>
-        /// <value>
-        /// The file data.
-        /// </value>
-        [JsonProperty("file_data")]
         public String FileData { get; set; }
 
-        /// <summary>
-        /// Gets or sets the filename.
-        /// </summary>
-        /// <value>
-        /// The filename.
-        /// </value>
-        [JsonProperty("file_name")]
         public String Filename { get; set; }
 
-        /// <summary>
-        /// Gets or sets the type of the file.
-        /// </summary>
-        /// <value>
-        /// The type of the file.
-        /// </value>
-        [JsonProperty("file_type")]
         public FileType FileType { get; set; }
-
-        #endregion
     }
 }

--- a/MessagingService.DataTransferObjects/MessagingService.DataTransferObjects.csproj
+++ b/MessagingService.DataTransferObjects/MessagingService.DataTransferObjects.csproj
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+    
   </ItemGroup>
 
 </Project>

--- a/MessagingService.DataTransferObjects/ResendEmailRequest.cs
+++ b/MessagingService.DataTransferObjects/ResendEmailRequest.cs
@@ -2,15 +2,11 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
+    
     [ExcludeFromCodeCoverage]
     public class ResendEmailRequest
     {
-        [JsonProperty("message_id")]
         public Guid MessageId { get; set; }
-
-        [JsonProperty("connection_identifier")]
         public Guid ConnectionIdentifier { get; set; }
     }
 }

--- a/MessagingService.DataTransferObjects/ResendSMSRequest.cs
+++ b/MessagingService.DataTransferObjects/ResendSMSRequest.cs
@@ -2,14 +2,11 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
+    
     [ExcludeFromCodeCoverage]
     public class ResendSMSRequest{
-        [JsonProperty("message_id")]
         public Guid MessageId{ get; set; }
 
-        [JsonProperty("connection_identifier")]
         public Guid ConnectionIdentifier{ get; set; }
     }
 }

--- a/MessagingService.DataTransferObjects/SendEmailRequest.cs
+++ b/MessagingService.DataTransferObjects/SendEmailRequest.cs
@@ -3,8 +3,7 @@
     using System;
     using System.Collections.Generic;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
+    
     [ExcludeFromCodeCoverage]
     public class SendEmailRequest
     {
@@ -13,80 +12,20 @@
             this.EmailAttachments = new List<EmailAttachment>();
         }
 
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the message identifier.
-        /// </summary>
-        /// <value>
-        /// The message identifier.
-        /// </value>
-        [JsonProperty("message_id")]
         public Guid? MessageId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the body.
-        /// </summary>
-        /// <value>
-        /// The body.
-        /// </value>
-        [JsonProperty("body")]
         public String Body { get; set; }
 
-        /// <summary>
-        /// Gets or sets the connection identifier.
-        /// </summary>
-        /// <value>
-        /// The connection identifier.
-        /// </value>
-        [JsonProperty("connection_identifier")]
         public Guid ConnectionIdentifier { get; set; }
 
-        /// <summary>
-        /// Gets or sets from address.
-        /// </summary>
-        /// <value>
-        /// From address.
-        /// </value>
-        [JsonProperty("from_address")]
         public String FromAddress { get; set; }
 
-        /// <summary>
-        /// Gets or sets a value indicating whether this instance is HTML.
-        /// </summary>
-        /// <value>
-        ///   <c>true</c> if this instance is HTML; otherwise, <c>false</c>.
-        /// </value>
-        [JsonProperty("is_html")]
         public Boolean IsHtml { get; set; }
 
-        /// <summary>
-        /// Gets or sets the subject.
-        /// </summary>
-        /// <value>
-        /// The subject.
-        /// </value>
-        [JsonProperty("subject")]
         public String Subject { get; set; }
 
-        /// <summary>
-        /// Gets or sets to addresses.
-        /// </summary>
-        /// <value>
-        /// To addresses.
-        /// </value>
-        [JsonProperty("to_addresses")]
         public List<String> ToAddresses { get; set; }
 
-        /// <summary>
-        /// Gets or sets the email attachments.
-        /// </summary>
-        /// <value>
-        /// The email attachments.
-        /// </value>
-        [JsonProperty("email_attachements")]
         public List<EmailAttachment> EmailAttachments { get; set; }
-
-        #endregion
     }
 }

--- a/MessagingService.DataTransferObjects/SendEmailResponse.cs
+++ b/MessagingService.DataTransferObjects/SendEmailResponse.cs
@@ -2,25 +2,10 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
-
-    /// <summary>
-    /// 
-    /// </summary>
+    
     [ExcludeFromCodeCoverage]
     public class SendEmailResponse
     {
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the message identifier.
-        /// </summary>
-        /// <value>
-        /// The message identifier.
-        /// </value>
-        [JsonProperty("message_id")]
         public Guid MessageId { get; set; }
-
-        #endregion
     }
 }

--- a/MessagingService.DataTransferObjects/SendSMSRequest.cs
+++ b/MessagingService.DataTransferObjects/SendSMSRequest.cs
@@ -1,59 +1,19 @@
 ﻿namespace MessagingService.DataTransferObjects
 {
-    using Newtonsoft.Json;
     using System;
     using System.Diagnostics.CodeAnalysis;
     
     [ExcludeFromCodeCoverage]
     public class SendSMSRequest
     {
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the connection identifier.
-        /// </summary>
-        /// <value>
-        /// The connection identifier.
-        /// </value>
-        [JsonProperty("connection_identifier")]
         public Guid ConnectionIdentifier { get; set; }
 
-        /// <summary>
-        /// Gets or sets the destination.
-        /// </summary>
-        /// <value>
-        /// The destination.
-        /// </value>
-        [JsonProperty("destination")]
         public String Destination { get; set; }
 
-        /// <summary>
-        /// Gets or sets the message.
-        /// </summary>
-        /// <value>
-        /// The message.
-        /// </value>
-        [JsonProperty("message")]
         public String Message { get; set; }
 
-        /// <summary>
-        /// Gets or sets the message identifier.
-        /// </summary>
-        /// <value>
-        /// The message identifier.
-        /// </value>
-        [JsonProperty("message_id")]
         public Guid? MessageId { get; set; }
 
-        /// <summary>
-        /// Gets or sets the sender.
-        /// </summary>
-        /// <value>
-        /// The sender.
-        /// </value>
-        [JsonProperty("sender")]
         public String Sender { get; set; }
-
-        #endregion
     }
 }

--- a/MessagingService.DataTransferObjects/SendSMSResponse.cs
+++ b/MessagingService.DataTransferObjects/SendSMSResponse.cs
@@ -2,22 +2,10 @@
 {
     using System;
     using System.Diagnostics.CodeAnalysis;
-    using Newtonsoft.Json;
 
     [ExcludeFromCodeCoverage]
     public class SendSMSResponse
     {
-        #region Properties
-
-        /// <summary>
-        /// Gets or sets the message identifier.
-        /// </summary>
-        /// <value>
-        /// The message identifier.
-        /// </value>
-        [JsonProperty("message_id")]
         public Guid MessageId { get; set; }
-
-        #endregion
     }
 }

--- a/MessagingService.EmailAggregate.Tests/MessagingService.EmailAggregate.Tests.csproj
+++ b/MessagingService.EmailAggregate.Tests/MessagingService.EmailAggregate.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
+    <PackageReference Include="Shared.EventStore" Version="2026.5.4" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/MessagingService.EmailMessage.DomainEvents/MessagingService.EmailMessage.DomainEvents.csproj
+++ b/MessagingService.EmailMessage.DomainEvents/MessagingService.EmailMessage.DomainEvents.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Shared" Version="2026.3.1" />
-	<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
+	<PackageReference Include="Shared" Version="2026.5.4" />
+	<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.4" />
   </ItemGroup>
 
 </Project>

--- a/MessagingService.EmailMessageAggregate/MessagingService.EmailMessageAggregate.csproj
+++ b/MessagingService.EmailMessageAggregate/MessagingService.EmailMessageAggregate.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-	  <PackageReference Include="Shared" Version="2026.3.1" />
-	  <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
+	  <PackageReference Include="Shared" Version="2026.5.4" />
+	  <PackageReference Include="Shared.EventStore" Version="2026.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService.IntegrationTesting.Helpers/MessagingService.IntegrationTesting.Helpers.csproj
+++ b/MessagingService.IntegrationTesting.Helpers/MessagingService.IntegrationTesting.Helpers.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService.IntegrationTests/Common/DockerHelper.cs
+++ b/MessagingService.IntegrationTests/Common/DockerHelper.cs
@@ -10,6 +10,7 @@ namespace MessagingService.IntegrationTests.Common
     using Ductus.FluentDocker.Services.Extensions;
     using global::Shared.IntegrationTesting;
     using global::Shared.Logger;
+    using global::Shared.Serialisation;
     using IntegrationTesting.Helpers;
     using Microsoft.AspNetCore.Http;
     using SecurityService.Client;
@@ -82,10 +83,20 @@ namespace MessagingService.IntegrationTests.Common
             
             HttpClient httpClient = CreateHttpClient();
             
-            this.SecurityServiceClient = new SecurityServiceClient(SecurityServiceBaseAddressResolver, httpClient);
-            this.MessagingServiceClient = new MessagingServiceClient(MessagingServiceBaseAddressResolver, httpClient);
+            this.SecurityServiceClient = new SecurityServiceClient(SecurityServiceBaseAddressResolver, httpClient, Serialise, Deserialise);
+            this.MessagingServiceClient = new MessagingServiceClient(MessagingServiceBaseAddressResolver, httpClient, Serialise, Deserialise);
         }
         #endregion
+
+        String Serialise(Object arg)
+        {
+            return StringSerialiser.Serialise<Object>(arg);
+        }
+
+        Object Deserialise(String arg, Type type)
+        {
+            return StringSerialiser.DeserializeObject<Object>(arg, type);
+        }
 
         private HttpClient CreateHttpClient() {
             // Set up test HttpContext

--- a/MessagingService.IntegrationTests/Common/DockerHelper.cs
+++ b/MessagingService.IntegrationTests/Common/DockerHelper.cs
@@ -90,12 +90,12 @@ namespace MessagingService.IntegrationTests.Common
 
         String Serialise(Object arg)
         {
-            return StringSerialiser.Serialise<Object>(arg);
+            return StringSerialiser.Serialise<Object>(arg, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
         }
 
         Object Deserialise(String arg, Type type)
         {
-            return StringSerialiser.DeserializeObject<Object>(arg, type);
+            return StringSerialiser.DeserializeObject<Object>(arg, type, new SerialiserOptions(SerialiserPropertyFormat.SnakeCase));
         }
 
         private HttpClient CreateHttpClient() {

--- a/MessagingService.IntegrationTests/Common/TestingContext.cs
+++ b/MessagingService.IntegrationTests/Common/TestingContext.cs
@@ -1,13 +1,11 @@
 ﻿using Shared.Logger;
 using System;
 using System.Collections.Generic;
-using System.Text;
 
 namespace MessagingService.IntegrationTests.Common
 {
     using System.Linq;
     using DataTransferObjects;
-    using SecurityService.DataTransferObjects.Responses;
     using Shouldly;
 
     public class TestingContext

--- a/MessagingService.IntegrationTests/Email/SendEmailSteps.cs
+++ b/MessagingService.IntegrationTests/Email/SendEmailSteps.cs
@@ -3,21 +3,11 @@
 namespace MessagingService.IntegrationTests.Email
 {
     using System.Collections.Generic;
-    using System.Linq;
-    using System.Net;
-    using System.Net.Http;
-    using System.Net.Http.Headers;
-    using System.Text;
-    using System.Threading;
     using System.Threading.Tasks;
     using Common;
     using DataTransferObjects;
-    using global::Shared.IntegrationTesting;
     using IntegrationTesting.Helpers;
-    using Newtonsoft.Json;
     using Reqnroll;
-    using Shared;
-    using Shouldly;
 
     [Binding]
     [Scope(Tag = "email")]

--- a/MessagingService.IntegrationTests/MessagingService.IntegrationTests.csproj
+++ b/MessagingService.IntegrationTests/MessagingService.IntegrationTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.5.4" />
     <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
@@ -14,9 +14,9 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Reqnroll" Version="3.3.3" />
     <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-    <PackageReference Include="SecurityService.Client" Version="2026.2.3" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.2.3" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.3.1" />
+    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build154" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build154" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.4" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/MessagingService.IntegrationTests/MessagingService.IntegrationTests.csproj
+++ b/MessagingService.IntegrationTests/MessagingService.IntegrationTests.csproj
@@ -14,8 +14,8 @@
     <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
     <PackageReference Include="Reqnroll" Version="3.3.3" />
     <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build154" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build154" />
+    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build156" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build156" />
     <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.4" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">

--- a/MessagingService.IntegrationTests/SMS/SendSMS.feature.cs
+++ b/MessagingService.IntegrationTests/SMS/SendSMS.feature.cs
@@ -113,53 +113,53 @@ namespace MessagingService.IntegrationTests.SMS
         {
 #line 4
 #line hidden
-            global::Reqnroll.Table table1 = new global::Reqnroll.Table(new string[] {
+            global::Reqnroll.Table table6 = new global::Reqnroll.Table(new string[] {
                         "Name",
                         "DisplayName",
                         "Description"});
-            table1.AddRow(new string[] {
+            table6.AddRow(new string[] {
                         "messagingService",
                         "Messaging REST Scope",
                         "A scope for Messaging REST"});
 #line 6
- await testRunner.GivenAsync("I create the following api scopes", ((string)(null)), table1, "Given ");
+ await testRunner.GivenAsync("I create the following api scopes", ((string)(null)), table6, "Given ");
 #line hidden
-            global::Reqnroll.Table table2 = new global::Reqnroll.Table(new string[] {
+            global::Reqnroll.Table table7 = new global::Reqnroll.Table(new string[] {
                         "Name",
                         "DisplayName",
                         "Secret",
                         "Scopes",
                         "UserClaims"});
-            table2.AddRow(new string[] {
+            table7.AddRow(new string[] {
                         "messagingService",
                         "Messaging REST",
                         "Secret1",
                         "messagingService",
                         ""});
 #line 10
- await testRunner.GivenAsync("the following api resources exist", ((string)(null)), table2, "Given ");
+ await testRunner.GivenAsync("the following api resources exist", ((string)(null)), table7, "Given ");
 #line hidden
-            global::Reqnroll.Table table3 = new global::Reqnroll.Table(new string[] {
+            global::Reqnroll.Table table8 = new global::Reqnroll.Table(new string[] {
                         "ClientId",
                         "ClientName",
                         "Secret",
                         "Scopes",
                         "GrantTypes"});
-            table3.AddRow(new string[] {
+            table8.AddRow(new string[] {
                         "serviceClient",
                         "Service Client",
                         "Secret1",
                         "messagingService",
                         "client_credentials"});
 #line 14
- await testRunner.GivenAsync("the following clients exist", ((string)(null)), table3, "Given ");
+ await testRunner.GivenAsync("the following clients exist", ((string)(null)), table8, "Given ");
 #line hidden
-            global::Reqnroll.Table table4 = new global::Reqnroll.Table(new string[] {
+            global::Reqnroll.Table table9 = new global::Reqnroll.Table(new string[] {
                         "ClientId"});
-            table4.AddRow(new string[] {
+            table9.AddRow(new string[] {
                         "serviceClient"});
 #line 18
- await testRunner.GivenAsync("I have a token to access the messaging service resource", ((string)(null)), table4, "Given ");
+ await testRunner.GivenAsync("I have a token to access the messaging service resource", ((string)(null)), table9, "Given ");
 #line hidden
         }
         
@@ -193,16 +193,16 @@ this.ScenarioInitialize(scenarioInfo, ruleInfo);
 #line 4
 await this.FeatureBackgroundAsync();
 #line hidden
-                global::Reqnroll.Table table5 = new global::Reqnroll.Table(new string[] {
+                global::Reqnroll.Table table10 = new global::Reqnroll.Table(new string[] {
                             "Sender",
                             "Destination",
                             "Message"});
-                table5.AddRow(new string[] {
+                table10.AddRow(new string[] {
                             "TestSender",
                             "07777777771",
                             "TestSMSMessage"});
 #line 24
- await testRunner.GivenAsync("I send the following SMS Messages", ((string)(null)), table5, "Given ");
+ await testRunner.GivenAsync("I send the following SMS Messages", ((string)(null)), table10, "Given ");
 #line hidden
             }
             await this.ScenarioCleanupAsync();

--- a/MessagingService.IntegrationTests/Shared/SharedSteps.cs
+++ b/MessagingService.IntegrationTests/Shared/SharedSteps.cs
@@ -1,11 +1,7 @@
 ﻿using MessagingService.IntegrationTests.Common;
-using SecurityService.DataTransferObjects.Requests;
-using SecurityService.DataTransferObjects.Responses;
-using Shouldly;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Threading;
 using System.Threading.Tasks;
 

--- a/MessagingService.SMSMessage.DomainEvents/MessagingService.SMSMessage.DomainEvents.csproj
+++ b/MessagingService.SMSMessage.DomainEvents/MessagingService.SMSMessage.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.3.1" />
+    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.4" />
   </ItemGroup>
 
 </Project>

--- a/MessagingService.SMSMessageAggregate/MessagingService.SMSMessageAggregate.csproj
+++ b/MessagingService.SMSMessageAggregate/MessagingService.SMSMessageAggregate.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-    <PackageReference Include="Shared.EventStore" Version="2026.3.1" />
+    <PackageReference Include="Shared.EventStore" Version="2026.5.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService/Bootstrapper/MiddlewareRegistry.cs
+++ b/MessagingService/Bootstrapper/MiddlewareRegistry.cs
@@ -3,6 +3,10 @@ using Microsoft.Extensions.Logging;
 using Microsoft.IdentityModel.Tokens;
 using Microsoft.OpenApi;
 using Shared.Authorisation;
+using System;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Shared.Serialisation;
 
 namespace MessagingService.Bootstrapper
 {
@@ -50,6 +54,8 @@ namespace MessagingService.Bootstrapper
             RequestResponseMiddlewareLoggingConfig config = new(middlewareLogLevel, logRequests, logResponses);
 
             this.AddSingleton(config);
+
+            this.ConfigureHttpJsonOptions(jsonOptions => JsonSerializerConfiguration.ConfigureMinimalApi(jsonOptions.SerializerOptions));
         }
 
         private void ConfigureAuthentication() {
@@ -87,11 +93,11 @@ namespace MessagingService.Bootstrapper
             this.AddClientCredentialsOnlyPolicy();
             this.AddClientCredentialsHandler();
 
-            this.ConfigureHttpJsonOptions(options =>
-            {
-                options.SerializerOptions.PropertyNamingPolicy = new SnakeCaseNamingPolicy();
-                options.SerializerOptions.PropertyNameCaseInsensitive = true; // optional, but safer
-            });
+            //this.ConfigureHttpJsonOptions(options =>
+            //{
+            //    options.SerializerOptions.PropertyNamingPolicy = new SnakeCaseNamingPolicy();
+            //    options.SerializerOptions.PropertyNameCaseInsensitive = true; // optional, but safer
+            //});
         }
         private void ConfigureSwagger() {
             
@@ -124,6 +130,60 @@ namespace MessagingService.Bootstrapper
             });
 
             this.AddSwaggerExamplesFromAssemblyOf<SwaggerJsonConverter>();
+        }
+    }
+}
+
+public static class JsonSerializerConfiguration
+{
+    public static void ConfigureMinimalApi(JsonSerializerOptions serializerOptions)
+    {
+        var defaultOptions = SystemTextJsonSerializer.GetDefaultJsonSerializerOptions();
+        serializerOptions.PropertyNamingPolicy = defaultOptions.PropertyNamingPolicy;
+        serializerOptions.DictionaryKeyPolicy = defaultOptions.DictionaryKeyPolicy;
+        serializerOptions.ReferenceHandler = defaultOptions.ReferenceHandler;
+        serializerOptions.WriteIndented = defaultOptions.WriteIndented;
+        serializerOptions.Converters.Add(new UtcDateTimeJsonConverter());
+        serializerOptions.Converters.Add(new NullableUtcDateTimeJsonConverter());
+        
+    }
+
+    private sealed class UtcDateTimeJsonConverter : System.Text.Json.Serialization.JsonConverter<DateTime>
+    {
+        public override DateTime Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            var value = reader.GetDateTime();
+            return value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime();
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime value, JsonSerializerOptions options)
+        {
+            writer.WriteStringValue(value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime());
+        }
+    }
+
+    private sealed class NullableUtcDateTimeJsonConverter : System.Text.Json.Serialization.JsonConverter<DateTime?>
+    {
+        public override DateTime? Read(ref Utf8JsonReader reader, Type typeToConvert, JsonSerializerOptions options)
+        {
+            if (reader.TokenType == JsonTokenType.Null)
+            {
+                return null;
+            }
+
+            var value = reader.GetDateTime();
+            return value.Kind == DateTimeKind.Utc ? value : value.ToUniversalTime();
+        }
+
+        public override void Write(Utf8JsonWriter writer, DateTime? value, JsonSerializerOptions options)
+        {
+            if (value.HasValue == false)
+            {
+                writer.WriteNullValue();
+                return;
+            }
+
+            writer.WriteStringValue(value.Value.Kind == DateTimeKind.Utc ? value.Value : value.Value.ToUniversalTime());
         }
     }
 }

--- a/MessagingService/Bootstrapper/SerialiserRegistry.cs
+++ b/MessagingService/Bootstrapper/SerialiserRegistry.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Diagnostics.CodeAnalysis;
+using Lamar;
+using Microsoft.Extensions.DependencyInjection;
+using Shared.Serialisation;
+
+namespace MessagingService.Bootstrapper;
+
+[ExcludeFromCodeCoverage]
+public class SerialiserRegistry : ServiceRegistry
+{
+    public SerialiserRegistry()
+    {
+        this.AddSingleton<IStringSerialiser, SystemTextJsonSerializer>();
+        this.AddSingleton<Func<Object, String>>(_ => obj => StringSerialiser.Serialise(obj));
+        this.AddSingleton<Func<String, Type, Object>>(_ => (str, type) => StringSerialiser.DeserializeObject<Object>(str, type));
+        this.AddSingleton(SystemTextJsonSerializer.GetDefaultJsonSerializerOptions());
+    }
+}

--- a/MessagingService/Handlers/DomainEventHandlers.cs
+++ b/MessagingService/Handlers/DomainEventHandlers.cs
@@ -4,8 +4,6 @@ using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Http;
-using Newtonsoft.Json;
-using Newtonsoft.Json.Linq;
 using Shared.DomainDrivenDesign.EventSourcing;
 using Shared.EventStore.Aggregate;
 using Shared.EventStore.EventHandling;
@@ -50,7 +48,7 @@ public static class DomainEventHandlers
         }
         catch (Exception ex)
         {
-            string domainEventData = JsonConvert.SerializeObject(domainEvent);
+            string domainEventData = StringSerialiser.Serialise(domainEvent);
             Logger.LogError($"Failed to process event. Data received [{domainEventData}]", ex);
             throw;
         }
@@ -74,38 +72,14 @@ public static class DomainEventHandlers
         if (type == null)
             throw new NotFoundException($"Failed to find a domain event with type {eventType}");
 
-        var resolver = new JsonIgnoreAttributeIgnorerContractResolver();
-        var settings = new JsonSerializerSettings
-        {
-            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
-            TypeNameHandling = TypeNameHandling.All,
-            Formatting = Formatting.Indented,
-            DateTimeZoneHandling = DateTimeZoneHandling.Utc,
-            ContractResolver = resolver
-        };
-
         if (type.IsSubclassOf(typeof(DomainEvent)))
         {
-            string json = JsonConvert.SerializeObject(domainEvent, settings);
+            String json = StringSerialiser.Serialise(domainEvent);
 
             var factory = new DomainEventFactory();
-            string validatedJson = ValidateEvent(json);
-            return factory.CreateDomainEvent(validatedJson, type);
+            return factory.CreateDomainEvent(json, type);
         }
 
         return null;
-    }
-
-    private static string ValidateEvent(string domainEventJson)
-    {
-        var domainEvent = JObject.Parse(domainEventJson);
-
-        if (!domainEvent.ContainsKey("eventId") ||
-            domainEvent["eventId"]!.ToObject<Guid>() == Guid.Empty)
-        {
-            throw new ArgumentException("Domain Event must contain an Event Id");
-        }
-
-        return domainEventJson;
     }
 }

--- a/MessagingService/MessagingService.csproj
+++ b/MessagingService/MessagingService.csproj
@@ -21,13 +21,13 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="OpenIddict.Core" Version="7.4.0" />
-    <PackageReference Include="Shared" Version="2026.3.1" />
-	  <PackageReference Include="Shared.Logger" Version="2026.3.1" />
+    <PackageReference Include="Shared" Version="2026.5.4" />
+	  <PackageReference Include="Shared.Logger" Version="2026.5.4" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
     <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.3.1" />
-	  <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.5.4" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.5.4" />
     <PackageReference Include="SimpleResults.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />

--- a/MessagingService/Startup.cs
+++ b/MessagingService/Startup.cs
@@ -1,3 +1,4 @@
+using MessagingService.Endpoints;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.Configuration;
@@ -6,7 +7,6 @@ using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
-using MessagingService.Endpoints;
 
 namespace MessagingService
 {
@@ -26,6 +26,7 @@ namespace MessagingService
     using Shared.General;
     using Shared.Logger;
     using Shared.Middleware;
+    using Shared.Serialisation;
     using SMSMessage.DomainEvents;
     using System.Diagnostics;
     using System.Diagnostics.CodeAnalysis;
@@ -56,8 +57,12 @@ namespace MessagingService
             services.IncludeRegistry<DomainServiceRegistry>();
             services.IncludeRegistry<DomainEventHandlerRegistry>();
             services.IncludeRegistry<MessagingProxyRegistry>();
+            services.IncludeRegistry<SerialiserRegistry>();
 
             Startup.Container = new Container(services);
+
+            var serialiser = Container.GetRequiredService<IStringSerialiser>();
+            StringSerialiser.Initialise(serialiser);
         }
         
         // This method gets called by the runtime. Use this method to configure the HTTP request pipeline.


### PR DESCRIPTION
Removed all Newtonsoft.Json usage and attributes. Updated all serialization/deserialization to use StringSerialiser. Injected serialization delegates into clients and integration tests. Updated project dependencies to latest shared packages. Cleaned up related comments and regions. Improved consistency and maintainability across the codebase.

closes #389 