### PR TITLE
Downgrade client deps, remove NewtonsoftJson package

### DIFF
--- a/MessagingService.Client/MessagingService.Client.csproj
+++ b/MessagingService.Client/MessagingService.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
-    <PackageReference Include="Shared.Results" Version="2026.3.1" />
+    <PackageReference Include="ClientProxyBase" Version="2026.5.5" />
+    <PackageReference Include="Shared.Results" Version="2026.5.5" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/MessagingService.Client/MessagingService.Client.csproj
+++ b/MessagingService.Client/MessagingService.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.4" />
-    <PackageReference Include="Shared.Results" Version="2026.5.4" />
+    <PackageReference Include="ClientProxyBase" Version="2026.3.1" />
+    <PackageReference Include="Shared.Results" Version="2026.3.1" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/MessagingService.EmailAggregate.Tests/MessagingService.EmailAggregate.Tests.csproj
+++ b/MessagingService.EmailAggregate.Tests/MessagingService.EmailAggregate.Tests.csproj
@@ -8,7 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.4" />
+    <PackageReference Include="Shared.EventStore" Version="2026.5.5" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/MessagingService.EmailMessage.DomainEvents/MessagingService.EmailMessage.DomainEvents.csproj
+++ b/MessagingService.EmailMessage.DomainEvents/MessagingService.EmailMessage.DomainEvents.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Shared" Version="2026.5.4" />
-	<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.4" />
+	<PackageReference Include="Shared" Version="2026.5.5" />
+	<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.5" />
   </ItemGroup>
 
 </Project>

--- a/MessagingService.EmailMessageAggregate/MessagingService.EmailMessageAggregate.csproj
+++ b/MessagingService.EmailMessageAggregate/MessagingService.EmailMessageAggregate.csproj
@@ -6,8 +6,8 @@
 
   <ItemGroup>
 	  <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-	  <PackageReference Include="Shared" Version="2026.5.4" />
-	  <PackageReference Include="Shared.EventStore" Version="2026.5.4" />
+	  <PackageReference Include="Shared" Version="2026.5.5" />
+	  <PackageReference Include="Shared.EventStore" Version="2026.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService.IntegrationTesting.Helpers/MessagingService.IntegrationTesting.Helpers.csproj
+++ b/MessagingService.IntegrationTesting.Helpers/MessagingService.IntegrationTesting.Helpers.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.4" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService.IntegrationTests/MessagingService.IntegrationTests.csproj
+++ b/MessagingService.IntegrationTests/MessagingService.IntegrationTests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.4" />
+    <PackageReference Include="ClientProxyBase" Version="2026.5.5" />
     <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
     <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
@@ -16,7 +16,7 @@
     <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
     <PackageReference Include="SecurityService.Client" Version="2026.4.3-build156" />
     <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build156" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.4" />
+    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
     <PackageReference Include="Shouldly" Version="4.3.0" />
     <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>

--- a/MessagingService.SMSMessage.DomainEvents/MessagingService.SMSMessage.DomainEvents.csproj
+++ b/MessagingService.SMSMessage.DomainEvents/MessagingService.SMSMessage.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.4" />
+    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.5" />
   </ItemGroup>
 
 </Project>

--- a/MessagingService.SMSMessageAggregate/MessagingService.SMSMessageAggregate.csproj
+++ b/MessagingService.SMSMessageAggregate/MessagingService.SMSMessageAggregate.csproj
@@ -6,7 +6,7 @@
 
   <ItemGroup>
     <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.4" />
+    <PackageReference Include="Shared.EventStore" Version="2026.5.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService/MessagingService.csproj
+++ b/MessagingService/MessagingService.csproj
@@ -17,7 +17,6 @@
 	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
     <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="OpenIddict.Core" Version="7.4.0" />

--- a/MessagingService/MessagingService.csproj
+++ b/MessagingService/MessagingService.csproj
@@ -20,13 +20,13 @@
     <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
     <PackageReference Include="OpenIddict.Core" Version="7.4.0" />
-    <PackageReference Include="Shared" Version="2026.5.4" />
-	  <PackageReference Include="Shared.Logger" Version="2026.5.4" />
+    <PackageReference Include="Shared" Version="2026.5.5" />
+	  <PackageReference Include="Shared.Logger" Version="2026.5.5" />
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
     <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.5.4" />
-	  <PackageReference Include="ClientProxyBase" Version="2026.5.4" />
+    <PackageReference Include="Shared.Results.Web" Version="2026.5.5" />
+	  <PackageReference Include="ClientProxyBase" Version="2026.5.5" />
     <PackageReference Include="SimpleResults.AspNetCore" Version="4.0.0" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />


### PR DESCRIPTION
Downgraded ClientProxyBase and Shared.Results in MessagingService.Client.csproj from 2026.5.4 to 2026.3.1. Removed Microsoft.AspNetCore.Mvc.NewtonsoftJson package reference from MessagingService.csproj.

closes #383 