### PR TITLE
Enable Central Package Management for NuGet dependencies

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -1,0 +1,63 @@
+<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="ClientProxyBase" Version="2026.5.7" />
+    <PackageVersion Include="Shared.Results" Version="2026.5.7" />
+    <PackageVersion Include="NLog.Extensions.Logging" Version="6.1.3" />
+    <PackageVersion Include="MediatR" Version="14.1.0" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageVersion Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
+    <PackageVersion Include="SimpleResults" Version="4.0.0" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageVersion Include="Shared.EventStore" Version="2026.5.7" />
+    <PackageVersion Include="Shouldly" Version="4.3.0" />
+    <PackageVersion Include="xunit" Version="2.9.3" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
+    <PackageVersion Include="coverlet.msbuild" Version="10.0.1" />
+    <PackageVersion Include="Grpc.Net.Client" Version="2.80.0" />
+    <PackageVersion Include="Shared" Version="2026.5.7" />
+    <PackageVersion Include="Shared.DomainDrivenDesign" Version="2026.5.7" />
+    <PackageVersion Include="Shared.IntegrationTesting" Version="2026.5.7" />
+    <PackageVersion Include="Shared.Logger" Version="2026.5.7" />
+    <PackageVersion Include="Shared.Results.Web" Version="2026.5.7" />
+    <PackageVersion Include="Ductus.FluentDocker" Version="2.85.0" />
+    <PackageVersion Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.4" />
+    <PackageVersion Include="NUnit" Version="4.6.1" />
+    <PackageVersion Include="Lamar" Version="16.0.0" />
+    <PackageVersion Include="Moq" Version="4.20.72" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.11" />
+    <PackageVersion Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="coverlet.collector" Version="8.0.0" />
+    <PackageVersion Include="OpenIddict.Validation.AspNetCore" Version="7.5.0" />
+    <PackageVersion Include="OpenIddict.Validation.SystemNetHttp" Version="7.5.0" />
+    <PackageVersion Include="Lamar.Microsoft.DependencyInjection" Version="16.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
+    <PackageVersion Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
+    <PackageVersion Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
+    <PackageVersion Include="OpenIddict.Core" Version="7.5.0" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Console" Version="10.0.9" />
+    <PackageVersion Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
+    <PackageVersion Include="SimpleResults.AspNetCore" Version="4.0.0" />
+    <PackageVersion Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.Swagger" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.1" />
+    <PackageVersion Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.2.1" />
+    <PackageVersion Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.9" />
+    <PackageVersion Include="Sentry.AspNetCore" Version="6.6.0" />
+    <PackageVersion Include="NUnit3TestAdapter" Version="6.2.0" />
+    <PackageVersion Include="Reqnroll" Version="3.3.4" />
+    <PackageVersion Include="Reqnroll.NUnit" Version="3.3.4" />
+    <PackageVersion Include="SecurityService.Client" Version="2026.5.1" />
+    <PackageVersion Include="SecurityService.IntegrationTesting.Helpers" Version="2026.5.1" />
+    <PackageVersion Include="coverlet.collector" Version="10.0.1" />
+  </ItemGroup>
+</Project>

--- a/MessagingService.BusinessLogic.Tests/MessagingService.BusinessLogic.Tests.csproj
+++ b/MessagingService.BusinessLogic.Tests/MessagingService.BusinessLogic.Tests.csproj
@@ -7,16 +7,16 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lamar" Version="15.0.1" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Lamar" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MessagingService.BusinessLogic/MessagingService.BusinessLogic.csproj
+++ b/MessagingService.BusinessLogic/MessagingService.BusinessLogic.csproj
@@ -5,13 +5,13 @@
 	</PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
-    <PackageReference Include="MediatR" Version="14.1.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.3" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.3" />
-    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" Version="9.0.0" />
-    <PackageReference Include="SimpleResults" Version="4.0.0" />
+    <PackageReference Include="NLog.Extensions.Logging" />
+    <PackageReference Include="MediatR" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" />
+    <PackageReference Include="Pomelo.EntityFrameworkCore.MySql" />
+    <PackageReference Include="SimpleResults" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService.Client/MessagingService.Client.csproj
+++ b/MessagingService.Client/MessagingService.Client.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.5" />
-    <PackageReference Include="Shared.Results" Version="2026.5.5" />
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="Shared.Results" />
   </ItemGroup>
 	
   <ItemGroup>

--- a/MessagingService.EmailAggregate.Tests/MessagingService.EmailAggregate.Tests.csproj
+++ b/MessagingService.EmailAggregate.Tests/MessagingService.EmailAggregate.Tests.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.5" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shared.EventStore" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MessagingService.EmailMessage.DomainEvents/MessagingService.EmailMessage.DomainEvents.csproj
+++ b/MessagingService.EmailMessage.DomainEvents/MessagingService.EmailMessage.DomainEvents.csproj
@@ -6,8 +6,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-	<PackageReference Include="Shared" Version="2026.5.5" />
-	<PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.5" />
+	<PackageReference Include="Shared" />
+	<PackageReference Include="Shared.DomainDrivenDesign" />
   </ItemGroup>
 
 </Project>

--- a/MessagingService.EmailMessageAggregate/MessagingService.EmailMessageAggregate.csproj
+++ b/MessagingService.EmailMessageAggregate/MessagingService.EmailMessageAggregate.csproj
@@ -4,10 +4,10 @@
 	  <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
-  <ItemGroup>
-	  <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-	  <PackageReference Include="Shared" Version="2026.5.5" />
-	  <PackageReference Include="Shared.EventStore" Version="2026.5.5" />
+	<ItemGroup>
+	  <PackageReference Include="Grpc.Net.Client" />
+	  <PackageReference Include="Shared" />
+	  <PackageReference Include="Shared.EventStore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService.IntegrationTesting.Helpers/MessagingService.IntegrationTesting.Helpers.csproj
+++ b/MessagingService.IntegrationTesting.Helpers/MessagingService.IntegrationTesting.Helpers.csproj
@@ -7,7 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
+	<PackageReference Include="Shared.IntegrationTesting" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService.IntegrationTests/MessagingService.IntegrationTests.csproj
+++ b/MessagingService.IntegrationTests/MessagingService.IntegrationTests.csproj
@@ -6,19 +6,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="ClientProxyBase" Version="2026.5.5" />
-    <PackageReference Include="Ductus.FluentDocker" Version="2.85.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" Version="3.3.3" />
-	  <PackageReference Include="NUnit" Version="4.5.1" />
-    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
-    <PackageReference Include="Reqnroll" Version="3.3.3" />
-    <PackageReference Include="Reqnroll.NUnit" Version="3.3.3" />
-    <PackageReference Include="SecurityService.Client" Version="2026.4.3-build156" />
-    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" Version="2026.4.3-build156" />
-    <PackageReference Include="Shared.IntegrationTesting" Version="2026.5.5" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="coverlet.collector" Version="8.0.0">
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="Ductus.FluentDocker" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Reqnroll.Tools.MsBuild.Generation" />
+        <PackageReference Include="NUnit" />
+    <PackageReference Include="NUnit3TestAdapter" />
+    <PackageReference Include="Reqnroll" />
+    <PackageReference Include="Reqnroll.NUnit" />
+    <PackageReference Include="SecurityService.Client" />
+    <PackageReference Include="SecurityService.IntegrationTesting.Helpers" />
+    <PackageReference Include="Shared.IntegrationTesting" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MessagingService.SMSAggregate.Tests/MessagingService.SMSAggregate.Tests.csproj
+++ b/MessagingService.SMSAggregate.Tests/MessagingService.SMSAggregate.Tests.csproj
@@ -7,14 +7,14 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+    <PackageReference Include="coverlet.msbuild">
 	    <PrivateAssets>all</PrivateAssets>
 	    <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MessagingService.SMSMessage.DomainEvents/MessagingService.SMSMessage.DomainEvents.csproj
+++ b/MessagingService.SMSMessage.DomainEvents/MessagingService.SMSMessage.DomainEvents.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Shared.DomainDrivenDesign" Version="2026.5.5" />
+    <PackageReference Include="Shared.DomainDrivenDesign" />
   </ItemGroup>
 
 </Project>

--- a/MessagingService.SMSMessageAggregate/MessagingService.SMSMessageAggregate.csproj
+++ b/MessagingService.SMSMessageAggregate/MessagingService.SMSMessageAggregate.csproj
@@ -5,8 +5,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Grpc.Net.Client" Version="2.76.0" />
-    <PackageReference Include="Shared.EventStore" Version="2026.5.5" />
+    <PackageReference Include="Grpc.Net.Client" />
+    <PackageReference Include="Shared.EventStore" />
   </ItemGroup>
 
   <ItemGroup>

--- a/MessagingService.Tests/MessagingService.Tests.csproj
+++ b/MessagingService.Tests/MessagingService.Tests.csproj
@@ -7,18 +7,18 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" Version="2.3.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" Version="10.0.3" />
-   <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />
-    <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="Shouldly" Version="4.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Core" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.Testing" />
+   <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" />
+    <PackageReference Include="Moq" />
+    <PackageReference Include="Shouldly" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.msbuild" Version="8.0.0">
+    <PackageReference Include="coverlet.msbuild">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/MessagingService.sln
+++ b/MessagingService.sln
@@ -39,6 +39,11 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagingService.Models", "
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "MessagingService.IntegrationTesting.Helpers", "MessagingService.IntegrationTesting.Helpers\MessagingService.IntegrationTesting.Helpers.csproj", "{ED8848E7-1330-4B8D-8E5F-6E712C77AA87}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{A9C2E3D1-6F3B-4C5A-9C8E-111111111111}"
+	ProjectSection(SolutionItems) = preProject
+		Directory.Packages.props = Directory.Packages.props
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/MessagingService/Dockerfile
+++ b/MessagingService/Dockerfile
@@ -15,6 +15,8 @@ COPY ["MessagingService.BusinessLogic/MessagingService.BusinessLogic.csproj", "M
 COPY ["MessagingService.EmailMessageAggregate/MessagingService.EmailMessageAggregate.csproj", "MessagingService.EmailMessageAggregate/"]
 COPY ["MessagingService.EmailMessage.DomainEvents/MessagingService.EmailMessage.DomainEvents.csproj", "MessagingService.EmailMessage.DomainEvents/"]
 COPY ["MessagingService.DataTransferObjects/MessagingService.DataTransferObjects.csproj", "MessagingService.DataTransferObjects/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "MessagingService/MessagingService.csproj"
 COPY . .
 WORKDIR "/src/MessagingService"

--- a/MessagingService/Dockerfilewindows
+++ b/MessagingService/Dockerfilewindows
@@ -10,6 +10,8 @@ COPY ["MessagingService.BusinessLogic/MessagingService.BusinessLogic.csproj", "M
 COPY ["MessagingService.EmailMessageAggregate/MessagingService.EmailMessageAggregate.csproj", "MessagingService.EmailMessageAggregate/"]
 COPY ["MessagingService.EmailMessage.DomainEvents/MessagingService.EmailMessage.DomainEvents.csproj", "MessagingService.EmailMessage.DomainEvents/"]
 COPY ["MessagingService.DataTransferObjects/MessagingService.DataTransferObjects.csproj", "MessagingService.DataTransferObjects/"]
+COPY ["Directory.Packages.props", "."]
+COPY . .
 RUN dotnet restore "MessagingService/MessagingService.csproj"
 COPY . .
 WORKDIR "/src/MessagingService"

--- a/MessagingService/MessagingService.csproj
+++ b/MessagingService/MessagingService.csproj
@@ -3,6 +3,7 @@
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
     <DockerDefaultTargetOS>Linux</DockerDefaultTargetOS>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -10,32 +11,32 @@
   </PropertyGroup>
 
   <ItemGroup>
-	  <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.4.0" />
-	  <PackageReference Include="OpenIddict.Validation.SystemNetHttp" Version="7.4.0" />
-	  <PackageReference Include="Lamar" Version="15.0.1" />
-	  <PackageReference Include="Lamar.Microsoft.DependencyInjection" Version="15.0.1" />
-	  <PackageReference Include="AspNetCore.HealthChecks.UI.Client" Version="9.0.0" />
-    <PackageReference Include="AspNetCore.HealthChecks.Uris" Version="9.0.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
-    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="OpenIddict.Core" Version="7.4.0" />
-    <PackageReference Include="Shared" Version="2026.5.5" />
-	  <PackageReference Include="Shared.Logger" Version="2026.5.5" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.3" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.3" />
-    <PackageReference Include="NLog.Extensions.Logging" Version="6.1.2" />
-    <PackageReference Include="Shared.Results.Web" Version="2026.5.5" />
-	  <PackageReference Include="ClientProxyBase" Version="2026.5.5" />
-    <PackageReference Include="SimpleResults.AspNetCore" Version="4.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.4" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" Version="10.1.4" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="10.0.3" />
-	  <PackageReference Include="Sentry.AspNetCore" Version="6.2.0" />
+      <PackageReference Include="OpenIddict.Validation.AspNetCore" />
+      <PackageReference Include="OpenIddict.Validation.SystemNetHttp" />
+      <PackageReference Include="Lamar" />
+      <PackageReference Include="Lamar.Microsoft.DependencyInjection" />
+      <PackageReference Include="AspNetCore.HealthChecks.UI.Client" />
+    <PackageReference Include="AspNetCore.HealthChecks.Uris" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" />
+    <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" />
+    <PackageReference Include="OpenIddict.Core" />
+    <PackageReference Include="Shared" />
+    <PackageReference Include="Shared.Logger" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Debug" />
+    <PackageReference Include="NLog.Extensions.Logging" />
+    <PackageReference Include="Shared.Results.Web" />
+    <PackageReference Include="ClientProxyBase" />
+    <PackageReference Include="SimpleResults.AspNetCore" />
+    <PackageReference Include="Swashbuckle.AspNetCore" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Filters" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Swagger" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerUI" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" />
+    <PackageReference Include="Sentry.AspNetCore" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Introduce Directory.Packages.props to centrally manage all NuGet package versions. Remove explicit version numbers from all project files and update them to reference packages without versions. Set ManagePackageVersionsCentrally in the main project and add the central props file to the solution. This simplifies dependency management and ensures consistency across the solution.

closes #401